### PR TITLE
Adds support for buttons on notifications

### DIFF
--- a/src/HASS.Agent.Staging/HASS.Agent/HomeAssistant/HassApiManager.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/HomeAssistant/HassApiManager.cs
@@ -27,6 +27,7 @@ namespace HASS.Agent.HomeAssistant
         private static ServiceClient _serviceClient;
         private static EntityClient _entityClient;
         private static StatesClient _statesClient;
+        private static EventClient _eventClient;
 
         internal static HassManagerStatus ManagerStatus = HassManagerStatus.Initialising;
         private static string _haVersion = string.Empty;
@@ -101,6 +102,7 @@ namespace HASS.Agent.HomeAssistant
                 _serviceClient = ClientFactory.GetClient<ServiceClient>();
                 _entityClient = ClientFactory.GetClient<EntityClient>();
                 _statesClient = ClientFactory.GetClient<StatesClient>();
+                _eventClient = ClientFactory.GetClient<EventClient>();
 
                 // load entities
                 ManagerStatus = HassManagerStatus.LoadingData;
@@ -686,6 +688,16 @@ namespace HASS.Agent.HomeAssistant
 
             var actionValue = action.GetCategory();
             return $"{domainValue}.{actionValue}";
+        }
+
+        /// <summary>
+        /// Fires an event for the specified type and payload
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="payload"></param>
+        public static async Task FireEvent(string type, object payload)
+        {
+            await _eventClient.FireEvent(type, payload);
         }
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent/Managers/NotificationManager.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Managers/NotificationManager.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using HASS.Agent.Functions;
+﻿using HASS.Agent.Functions;
 using HASS.Agent.HomeAssistant;
 using HASS.Agent.Models.HomeAssistant;
 using Microsoft.Toolkit.Uwp.Notifications;
@@ -65,7 +60,7 @@ namespace HASS.Agent.Managers
                 toastBuilder.AddHeader("HASS.Agent", notification.Title, string.Empty);
 
                 // prepare image
-                if (!string.IsNullOrWhiteSpace(notification.Data.Image))
+                if (!string.IsNullOrWhiteSpace(notification.Data?.Image))
                 {
                     var (success, localFile) = await StorageManager.DownloadImageAsync(notification.Data.Image);
                     if (success) toastBuilder.AddInlineImage(new Uri(localFile));
@@ -75,16 +70,19 @@ namespace HASS.Agent.Managers
                 // prepare message
                 toastBuilder.AddText(notification.Message);
 
-                if (notification.Data.Actions.Count > 0)
+                if (notification.Data?.Actions.Count > 0)
                 {
                     foreach (var action in notification.Data.Actions)
                     {
-                        toastBuilder.AddButton(action.Title, ToastActivationType.Background, action.Action);
+                        if (!string.IsNullOrEmpty(action.Action))
+                        {
+                            toastBuilder.AddButton(action.Title, ToastActivationType.Background, action.Action);
+                        }
                     }
                 }
 
                 // check for duration limit
-                if (notification.Data.Duration > 0)
+                if (notification.Data?.Duration > 0)
                 {
                     // there's a duration added, so show for x seconds
                     // todo: unreliable

--- a/src/HASS.Agent.Staging/HASS.Agent/Models/HomeAssistant/Notification.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Models/HomeAssistant/Notification.cs
@@ -8,7 +8,7 @@ namespace HASS.Agent.Models.HomeAssistant
         public string Title { get; set; }
     }
 
-    public class NotificationExtraData
+    public class NotificationData
     {
         public int Duration { get; set; } = 0;
         public string Image { get; set; }
@@ -26,6 +26,6 @@ namespace HASS.Agent.Models.HomeAssistant
         public string Message { get; set; }
         public string Title { get; set; }
 
-        public NotificationExtraData Data { get; set; } = new();
+        public NotificationData Data { get; set; } = new();
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent/Models/HomeAssistant/Notification.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Models/HomeAssistant/Notification.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json.Serialization;
-
-namespace HASS.Agent.Models.HomeAssistant
+﻿namespace HASS.Agent.Models.HomeAssistant
 {
     public class NotificationAction
     {

--- a/src/HASS.Agent.Staging/HASS.Agent/Models/HomeAssistant/Notification.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Models/HomeAssistant/Notification.cs
@@ -1,5 +1,21 @@
-﻿namespace HASS.Agent.Models.HomeAssistant
+﻿using System.Text.Json.Serialization;
+
+namespace HASS.Agent.Models.HomeAssistant
 {
+    public class NotificationAction
+    {
+        public string Action { get; set; }
+        public string Title { get; set; }
+    }
+
+    public class NotificationExtraData
+    {
+        public int Duration { get; set; } = 0;
+        public string Image { get; set; }
+
+        public List<NotificationAction> Actions { get; set; } = new();
+    }
+    
     public class Notification
     {
         public Notification()
@@ -9,7 +25,7 @@
 
         public string Message { get; set; }
         public string Title { get; set; }
-        public string Image { get; set; }
-        public int Duration { get; set; } = 0;
+
+        public NotificationExtraData Data { get; set; } = new();
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent/Models/HomeAssistant/Notification.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Models/HomeAssistant/Notification.cs
@@ -16,14 +16,9 @@
     
     public class Notification
     {
-        public Notification()
-        {
-            //
-        }
-
         public string Message { get; set; }
         public string Title { get; set; }
 
-        public NotificationData Data { get; set; } = new();
+        public NotificationData Data { get; set; }
     }
 }


### PR DESCRIPTION
This adds support for adding buttons to the notifications which can be reacted to within Home Assistant.

Whenever a button is pressed an event will be triggered in Home Assistant which you can create automation upon.

### Example of an event trigger:
![image](https://user-images.githubusercontent.com/5894204/189635867-3a55de8c-2ba8-45ab-9692-a26770c6b8fb.png)

Every event also includes the device name to filter which device sent the event.

### How to send a notification with buttons:
![image](https://user-images.githubusercontent.com/5894204/189636004-a968e092-085c-472c-9e95-7e73b440f45c.png)

Just add a list of actions just like how actionable notifications works in the companion app for Home Assistant.
https://companion.home-assistant.io/docs/notifications/actionable-notifications/#building-actionable-notifications


In order for this to work a modification to HASS.Agent-Notifier had to made. See PR [here](https://github.com/LAB02-Research/HASS.Agent-Notifier/pull/23).


