### PR TITLE
Mic and webcam return each process as an attribute

### DIFF
--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneProcessSensor.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/MicrophoneProcessSensor.cs
@@ -45,10 +45,9 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             if (UseAttributes)
             {
                 model.Json_attributes_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/attributes";
-                model.Json_attributes_template = "{{ value_json | tojson }}";
             }
 
-            return SetAutoDiscoveryConfigModel(model);
+            return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(model);
         }
 
         private string MicrophoneProcess()

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamProcessSensor.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamProcessSensor.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 {
     /// <summary>
-    /// Sensor indicating whether the mic is in use
+    /// Sensor indicating whether the webcam is in use
     /// </summary>
     public class WebcamProcessSensor : AbstractSingleValueSensor
     {
@@ -45,10 +45,9 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             if (UseAttributes)
             {
                 model.Json_attributes_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/attributes";
-                model.Json_attributes_template = "{{ value_json | tojson }}";
             }
 
-            return SetAutoDiscoveryConfigModel(model);
+            return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(model);
         }
 
         private string WebcamProcess()
@@ -80,7 +79,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
         private void CheckRegForWebcamInUse(RegistryKey key)
         {
-            if (key == null) return; ;
+            if (key == null) return;
 
             foreach (var subKeyName in key.GetSubKeyNames())
             {

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamProcessSensor.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/WebcamProcessSensor.cs
@@ -1,7 +1,9 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using HASS.Agent.Shared.Functions;
 using HASS.Agent.Shared.Models.HomeAssistant;
 using Microsoft.Win32;
+using Newtonsoft.Json;
 
 namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 {
@@ -10,12 +12,18 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
     /// </summary>
     public class WebcamProcessSensor : AbstractSingleValueSensor
     {
-        public WebcamProcessSensor(int? updateInterval = null, string name = "webcamprocess", string id = default) : base(name ?? "webcamprocess", updateInterval ?? 10, id)
+        public WebcamProcessSensor(int? updateInterval = null, string name = "webcamprocess", string id = default, bool useAttributes = true) : base(name ?? "webcamprocess", updateInterval ?? 10, id, useAttributes)
         {
             //
         }
 
+        private Dictionary<string, string> processes = new Dictionary<string, string>();
+
+        private string _attributes = string.Empty;
+
         public override string GetState() => WebcamProcess();
+        public void SetAttributes(string value) => _attributes = string.IsNullOrWhiteSpace(value) ? "{}" : value;
+        public override string GetAttributes() => _attributes;
 
         public override DiscoveryConfigModel GetAutoDiscoveryConfig()
         {
@@ -24,7 +32,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
             var deviceConfig = Variables.MqttManager.GetDeviceConfigModel();
             if (deviceConfig == null) return null;
 
-            return AutoDiscoveryConfigModel ?? SetAutoDiscoveryConfigModel(new SensorDiscoveryConfigModel()
+            var model = new SensorDiscoveryConfigModel()
             {
                 Name = Name,
                 Unique_id = Id,
@@ -32,37 +40,47 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
                 State_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/state",
                 Availability_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/sensor/{deviceConfig.Name}/availability",
                 Icon = "mdi:webcam"
-            });
+            };
+
+            if (UseAttributes)
+            {
+                model.Json_attributes_topic = $"{Variables.MqttManager.MqttDiscoveryPrefix()}/{Domain}/{deviceConfig.Name}/{ObjectId}/attributes";
+                model.Json_attributes_template = "{{ value_json | tojson }}";
+            }
+
+            return SetAutoDiscoveryConfigModel(model);
         }
 
-        public override string GetAttributes() => string.Empty;
-
-        private static string WebcamProcess()
+        private string WebcamProcess()
         {
             const string regKey = @"SOFTWARE\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\webcam";
-            (bool, string) inUse;
+
+            this.processes.Clear();
 
             // first local machine
             using (var key = Registry.LocalMachine.OpenSubKey(regKey))
             {
-                inUse = CheckRegForWebcamInUse(key);
-                if (inUse.Item1) return inUse.Item2;
+                CheckRegForWebcamInUse(key);
             }
 
             // then current user
             using (var key = Registry.CurrentUser.OpenSubKey(regKey))
             {
-                inUse = CheckRegForWebcamInUse(key);
-                if (inUse.Item1) return inUse.Item2;
+                CheckRegForWebcamInUse(key);
+            }
+
+            if (this.processes.Count > 0)
+            {
+                _attributes = JsonConvert.SerializeObject(this.processes, Formatting.Indented);
             }
 
             // nope
-            return string.Empty;
+            return this.processes.Count.ToString();
         }
 
-        private static (bool active, string application) CheckRegForWebcamInUse(RegistryKey key)
+        private void CheckRegForWebcamInUse(RegistryKey key)
         {
-            if (key == null) return (false, string.Empty);
+            if (key == null) return; ;
 
             foreach (var subKeyName in key.GetSubKeyNames())
             {
@@ -81,7 +99,10 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
                             ? (long)(subKey.GetValue("LastUsedTimeStop") ?? -1)
                             : -1;
 
-                        if (endTime <= 0) return (true, SharedHelperFunctions.ParseRegWebcamMicApplicationName(subKey.Name));
+                        if (endTime <= 0)
+                        {
+                            this.processes.Add(SharedHelperFunctions.ParseRegWebcamMicApplicationName(subKey.Name), "on");
+                        }
                     }
                 }
                 else
@@ -90,11 +111,12 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
                     if (subKey == null || !subKey.GetValueNames().Contains("LastUsedTimeStop")) continue;
 
                     var endTime = subKey.GetValue("LastUsedTimeStop") is long ? (long)(subKey.GetValue("LastUsedTimeStop") ?? -1) : -1;
-                    if (endTime <= 0) return (true, SharedHelperFunctions.ParseRegWebcamMicApplicationName(subKey.Name));
+                    if (endTime <= 0)
+                    {
+                        this.processes.Add(SharedHelperFunctions.ParseRegWebcamMicApplicationName(subKey.Name), "on");
+                    }
                 }
             }
-
-            return (false, string.Empty);
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/LAB02-Research/HASS.Agent/issues/249

The state is now the number of processes using the mic or webcam, and each process is added as an attribute. This removes the need to do any template string parsing for automation triggers/conditions.

![image](https://user-images.githubusercontent.com/7110658/212776023-8208c0e2-b9e3-4080-9719-e91fb5f887bd.png)
