### PR TITLE
Add configured retain flag to single value sensors

### DIFF
--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/Models/HomeAssistant/AbstractSingleValueSensor.cs
@@ -56,7 +56,7 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
                 {
                     if (LastUpdated.HasValue && LastUpdated.Value.AddSeconds(UpdateIntervalSeconds) > DateTime.Now) return;
                 }
-            
+
                 // get the current state/attributes
                 var state = GetState();
                 var attributes = GetAttributes();
@@ -75,6 +75,7 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
                 var message = new MqttApplicationMessageBuilder()
                     .WithTopic(autoDiscoConfig.State_topic)
                     .WithPayload(state)
+                    .WithRetainFlag(Variables.MqttManager.UseRetainFlag())
                     .Build();
 
                 // send it
@@ -91,6 +92,7 @@ namespace HASS.Agent.Shared.Models.HomeAssistant
                     message = new MqttApplicationMessageBuilder()
                         .WithTopic(autoDiscoConfig.Json_attributes_topic)
                         .WithPayload(attributes)
+                        .WithRetainFlag(Variables.MqttManager.UseRetainFlag())
                         .Build();
 
                     published = await Variables.MqttManager.PublishAsync(message);


### PR DESCRIPTION
This will fix https://github.com/LAB02-Research/HASS.Agent/issues/239.

I've had this version of HASS.Agent.Shared run locally for a few months now without issue.  I'm no longer seeing issues w/ sensors becoming Unavailable after an HA restart.