### PR TITLE
Fix: GPU temperature and load sensor fix

### DIFF
--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuLoadSensor.cs
@@ -25,7 +25,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
                 IsNetworkEnabled = false,
                 IsStorageEnabled = false,
             };
-            
+
             computer.Open();
             _gpu = computer.Hardware.FirstOrDefault(h => h.HardwareType == HardwareType.GpuAmd || h.HardwareType == HardwareType.GpuNvidia);
 
@@ -53,14 +53,17 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
         public override string GetState()
         {
-            if (_gpu == null) return "NotSupported";
+            if (_gpu == null)
+                return null;
 
             _gpu.Update();
+
             var sensor = _gpu.Sensors.FirstOrDefault(s => s.SensorType == SensorType.Load);
 
-            if (sensor?.Value == null) return "NotSupported";
+            if (sensor?.Value == null)
+                return null;
 
-            return sensor.Value.HasValue ? sensor.Value.Value.ToString("#.##", CultureInfo.InvariantCulture) : "Unknown";
+            return sensor.Value.HasValue ? sensor.Value.Value.ToString("#.##", CultureInfo.InvariantCulture) : null;
         }
 
         public override string GetAttributes() => string.Empty;

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/GeneralSensors/SingleValue/GpuTemperatureSensor.cs
@@ -54,14 +54,17 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors.GeneralSensors.SingleValue
 
         public override string GetState()
         {
-            if (_gpu == null) return "NotSupported";
+            if (_gpu == null)
+                return null;
 
             _gpu.Update();
+
             var sensor = _gpu.Sensors.FirstOrDefault(s => s.SensorType == SensorType.Temperature);
 
-            if (sensor?.Value == null) return "NotSupported";
+            if (sensor?.Value == null)
+                return null;
 
-            return sensor.Value.HasValue ? sensor.Value.Value.ToString("#.##", CultureInfo.InvariantCulture) : "Unknown";
+            return sensor.Value.HasValue ? sensor.Value.Value.ToString("#.##", CultureInfo.InvariantCulture) : null;
         }
 
         public override string GetAttributes() => string.Empty;


### PR DESCRIPTION
The current implementation of GPU temperature and load sensor does not adhere to the HA MQTT standard and can return string "NotSupported" or "Unknown" values which causes HA to produce an error/warning log - value of the state topic should always be a "convertible to number" value.

This PR does three things:
- allows sensors to return "null" value from "GetState()" and "GetAttributes()" functions
- in case "null" is returned for state, no update is sent (if attributes are "null" while state is not, only state is sent)
- changes the "GpuTemperatureSensor" and "GpuLoadSensor" to return null if information cannot be obtained

Should remediate https://github.com/LAB02-Research/HASS.Agent/issues/320 and partially remediate https://github.com/LAB02-Research/HASS.Agent/issues/310 .