### PR TITLE
Fix: key command and key emulation

### DIFF
--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/Functions/Inputs.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/Functions/Inputs.cs
@@ -1,0 +1,970 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace HASS.Agent.Shared.Functions
+{
+    /// <summary>
+    /// Class containing objects used by input emulation functions
+    /// </summary>
+    public class Inputs
+    {
+        /// Courtesy of http://www.pinvoke.net/default.aspx/Structures/INPUT.html
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INPUT
+        {
+            internal InputType type;
+            internal InputUnion U;
+            internal static int Size
+            {
+                get { return Marshal.SizeOf(typeof(INPUT)); }
+            }
+        }
+
+        public enum InputType : uint
+        {
+            INPUT_MOUSE,
+            INPUT_KEYBOARD,
+            INPUT_HARDWARE
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct InputUnion
+        {
+            [FieldOffset(0)]
+            internal MOUSEINPUT mi;
+            [FieldOffset(0)]
+            internal KEYBDINPUT ki;
+            [FieldOffset(0)]
+            internal HARDWAREINPUT hi;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MOUSEINPUT
+        {
+            internal int dx;
+            internal int dy;
+            internal int mouseData;
+            internal MOUSEEVENTF dwFlags;
+            internal uint time;
+            internal UIntPtr dwExtraInfo;
+        }
+
+        [Flags]
+        public enum MOUSEEVENTF : uint
+        {
+            ABSOLUTE = 0x8000,
+            HWHEEL = 0x01000,
+            MOVE = 0x0001,
+            MOVE_NOCOALESCE = 0x2000,
+            LEFTDOWN = 0x0002,
+            LEFTUP = 0x0004,
+            RIGHTDOWN = 0x0008,
+            RIGHTUP = 0x0010,
+            MIDDLEDOWN = 0x0020,
+            MIDDLEUP = 0x0040,
+            VIRTUALDESK = 0x4000,
+            WHEEL = 0x0800,
+            XDOWN = 0x0080,
+            XUP = 0x0100
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct KEYBDINPUT
+        {
+            internal VirtualKeyShort wVk;
+            internal ScanCodeShort wScan;
+            internal KEYEVENTF dwFlags;
+            internal int time;
+            internal UIntPtr dwExtraInfo;
+        }
+
+        [Flags]
+        public enum KEYEVENTF : uint
+        {
+            EXTENDEDKEY = 0x0001,
+            KEYUP = 0x0002,
+            SCANCODE = 0x0008,
+            UNICODE = 0x0004
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct HARDWAREINPUT
+        {
+            internal int uMsg;
+            internal short wParamL;
+            internal short wParamH;
+        }
+
+        public enum VirtualKeyShort : short
+        {
+            ///<summary>
+            ///Left mouse button
+            ///</summary>
+            LBUTTON = 0x01,
+            ///<summary>
+            ///Right mouse button
+            ///</summary>
+            RBUTTON = 0x02,
+            ///<summary>
+            ///Control-break processing
+            ///</summary>
+            CANCEL = 0x03,
+            ///<summary>
+            ///Middle mouse button (three-button mouse)
+            ///</summary>
+            MBUTTON = 0x04,
+            ///<summary>
+            ///Windows 2000/XP: X1 mouse button
+            ///</summary>
+            XBUTTON1 = 0x05,
+            ///<summary>
+            ///Windows 2000/XP: X2 mouse button
+            ///</summary>
+            XBUTTON2 = 0x06,
+            ///<summary>
+            ///BACKSPACE key
+            ///</summary>
+            BACK = 0x08,
+            ///<summary>
+            ///TAB key
+            ///</summary>
+            TAB = 0x09,
+            ///<summary>
+            ///CLEAR key
+            ///</summary>
+            CLEAR = 0x0C,
+            ///<summary>
+            ///ENTER key
+            ///</summary>
+            RETURN = 0x0D,
+            ///<summary>
+            ///SHIFT key
+            ///</summary>
+            SHIFT = 0x10,
+            ///<summary>
+            ///CTRL key
+            ///</summary>
+            CONTROL = 0x11,
+            ///<summary>
+            ///ALT key
+            ///</summary>
+            MENU = 0x12,
+            ///<summary>
+            ///PAUSE key
+            ///</summary>
+            PAUSE = 0x13,
+            ///<summary>
+            ///CAPS LOCK key
+            ///</summary>
+            CAPITAL = 0x14,
+            ///<summary>
+            ///Input Method Editor (IME) Kana mode
+            ///</summary>
+            KANA = 0x15,
+            ///<summary>
+            ///IME Hangul mode
+            ///</summary>
+            HANGUL = 0x15,
+            ///<summary>
+            ///IME Junja mode
+            ///</summary>
+            JUNJA = 0x17,
+            ///<summary>
+            ///IME final mode
+            ///</summary>
+            FINAL = 0x18,
+            ///<summary>
+            ///IME Hanja mode
+            ///</summary>
+            HANJA = 0x19,
+            ///<summary>
+            ///IME Kanji mode
+            ///</summary>
+            KANJI = 0x19,
+            ///<summary>
+            ///ESC key
+            ///</summary>
+            ESCAPE = 0x1B,
+            ///<summary>
+            ///IME convert
+            ///</summary>
+            CONVERT = 0x1C,
+            ///<summary>
+            ///IME nonconvert
+            ///</summary>
+            NONCONVERT = 0x1D,
+            ///<summary>
+            ///IME accept
+            ///</summary>
+            ACCEPT = 0x1E,
+            ///<summary>
+            ///IME mode change request
+            ///</summary>
+            MODECHANGE = 0x1F,
+            ///<summary>
+            ///SPACEBAR
+            ///</summary>
+            SPACE = 0x20,
+            ///<summary>
+            ///PAGE UP key
+            ///</summary>
+            PRIOR = 0x21,
+            ///<summary>
+            ///PAGE DOWN key
+            ///</summary>
+            NEXT = 0x22,
+            ///<summary>
+            ///END key
+            ///</summary>
+            END = 0x23,
+            ///<summary>
+            ///HOME key
+            ///</summary>
+            HOME = 0x24,
+            ///<summary>
+            ///LEFT ARROW key
+            ///</summary>
+            LEFT = 0x25,
+            ///<summary>
+            ///UP ARROW key
+            ///</summary>
+            UP = 0x26,
+            ///<summary>
+            ///RIGHT ARROW key
+            ///</summary>
+            RIGHT = 0x27,
+            ///<summary>
+            ///DOWN ARROW key
+            ///</summary>
+            DOWN = 0x28,
+            ///<summary>
+            ///SELECT key
+            ///</summary>
+            SELECT = 0x29,
+            ///<summary>
+            ///PRINT key
+            ///</summary>
+            PRINT = 0x2A,
+            ///<summary>
+            ///EXECUTE key
+            ///</summary>
+            EXECUTE = 0x2B,
+            ///<summary>
+            ///PRINT SCREEN key
+            ///</summary>
+            SNAPSHOT = 0x2C,
+            ///<summary>
+            ///INS key
+            ///</summary>
+            INSERT = 0x2D,
+            ///<summary>
+            ///DEL key
+            ///</summary>
+            DELETE = 0x2E,
+            ///<summary>
+            ///HELP key
+            ///</summary>
+            HELP = 0x2F,
+            ///<summary>
+            ///0 key
+            ///</summary>
+            KEY_0 = 0x30,
+            ///<summary>
+            ///1 key
+            ///</summary>
+            KEY_1 = 0x31,
+            ///<summary>
+            ///2 key
+            ///</summary>
+            KEY_2 = 0x32,
+            ///<summary>
+            ///3 key
+            ///</summary>
+            KEY_3 = 0x33,
+            ///<summary>
+            ///4 key
+            ///</summary>
+            KEY_4 = 0x34,
+            ///<summary>
+            ///5 key
+            ///</summary>
+            KEY_5 = 0x35,
+            ///<summary>
+            ///6 key
+            ///</summary>
+            KEY_6 = 0x36,
+            ///<summary>
+            ///7 key
+            ///</summary>
+            KEY_7 = 0x37,
+            ///<summary>
+            ///8 key
+            ///</summary>
+            KEY_8 = 0x38,
+            ///<summary>
+            ///9 key
+            ///</summary>
+            KEY_9 = 0x39,
+            ///<summary>
+            ///A key
+            ///</summary>
+            KEY_A = 0x41,
+            ///<summary>
+            ///B key
+            ///</summary>
+            KEY_B = 0x42,
+            ///<summary>
+            ///C key
+            ///</summary>
+            KEY_C = 0x43,
+            ///<summary>
+            ///D key
+            ///</summary>
+            KEY_D = 0x44,
+            ///<summary>
+            ///E key
+            ///</summary>
+            KEY_E = 0x45,
+            ///<summary>
+            ///F key
+            ///</summary>
+            KEY_F = 0x46,
+            ///<summary>
+            ///G key
+            ///</summary>
+            KEY_G = 0x47,
+            ///<summary>
+            ///H key
+            ///</summary>
+            KEY_H = 0x48,
+            ///<summary>
+            ///I key
+            ///</summary>
+            KEY_I = 0x49,
+            ///<summary>
+            ///J key
+            ///</summary>
+            KEY_J = 0x4A,
+            ///<summary>
+            ///K key
+            ///</summary>
+            KEY_K = 0x4B,
+            ///<summary>
+            ///L key
+            ///</summary>
+            KEY_L = 0x4C,
+            ///<summary>
+            ///M key
+            ///</summary>
+            KEY_M = 0x4D,
+            ///<summary>
+            ///N key
+            ///</summary>
+            KEY_N = 0x4E,
+            ///<summary>
+            ///O key
+            ///</summary>
+            KEY_O = 0x4F,
+            ///<summary>
+            ///P key
+            ///</summary>
+            KEY_P = 0x50,
+            ///<summary>
+            ///Q key
+            ///</summary>
+            KEY_Q = 0x51,
+            ///<summary>
+            ///R key
+            ///</summary>
+            KEY_R = 0x52,
+            ///<summary>
+            ///S key
+            ///</summary>
+            KEY_S = 0x53,
+            ///<summary>
+            ///T key
+            ///</summary>
+            KEY_T = 0x54,
+            ///<summary>
+            ///U key
+            ///</summary>
+            KEY_U = 0x55,
+            ///<summary>
+            ///V key
+            ///</summary>
+            KEY_V = 0x56,
+            ///<summary>
+            ///W key
+            ///</summary>
+            KEY_W = 0x57,
+            ///<summary>
+            ///X key
+            ///</summary>
+            KEY_X = 0x58,
+            ///<summary>
+            ///Y key
+            ///</summary>
+            KEY_Y = 0x59,
+            ///<summary>
+            ///Z key
+            ///</summary>
+            KEY_Z = 0x5A,
+            ///<summary>
+            ///Left Windows key (Microsoft Natural keyboard)
+            ///</summary>
+            LWIN = 0x5B,
+            ///<summary>
+            ///Right Windows key (Natural keyboard)
+            ///</summary>
+            RWIN = 0x5C,
+            ///<summary>
+            ///Applications key (Natural keyboard)
+            ///</summary>
+            APPS = 0x5D,
+            ///<summary>
+            ///Computer Sleep key
+            ///</summary>
+            SLEEP = 0x5F,
+            ///<summary>
+            ///Numeric keypad 0 key
+            ///</summary>
+            NUMPAD0 = 0x60,
+            ///<summary>
+            ///Numeric keypad 1 key
+            ///</summary>
+            NUMPAD1 = 0x61,
+            ///<summary>
+            ///Numeric keypad 2 key
+            ///</summary>
+            NUMPAD2 = 0x62,
+            ///<summary>
+            ///Numeric keypad 3 key
+            ///</summary>
+            NUMPAD3 = 0x63,
+            ///<summary>
+            ///Numeric keypad 4 key
+            ///</summary>
+            NUMPAD4 = 0x64,
+            ///<summary>
+            ///Numeric keypad 5 key
+            ///</summary>
+            NUMPAD5 = 0x65,
+            ///<summary>
+            ///Numeric keypad 6 key
+            ///</summary>
+            NUMPAD6 = 0x66,
+            ///<summary>
+            ///Numeric keypad 7 key
+            ///</summary>
+            NUMPAD7 = 0x67,
+            ///<summary>
+            ///Numeric keypad 8 key
+            ///</summary>
+            NUMPAD8 = 0x68,
+            ///<summary>
+            ///Numeric keypad 9 key
+            ///</summary>
+            NUMPAD9 = 0x69,
+            ///<summary>
+            ///Multiply key
+            ///</summary>
+            MULTIPLY = 0x6A,
+            ///<summary>
+            ///Add key
+            ///</summary>
+            ADD = 0x6B,
+            ///<summary>
+            ///Separator key
+            ///</summary>
+            SEPARATOR = 0x6C,
+            ///<summary>
+            ///Subtract key
+            ///</summary>
+            SUBTRACT = 0x6D,
+            ///<summary>
+            ///Decimal key
+            ///</summary>
+            DECIMAL = 0x6E,
+            ///<summary>
+            ///Divide key
+            ///</summary>
+            DIVIDE = 0x6F,
+            ///<summary>
+            ///F1 key
+            ///</summary>
+            F1 = 0x70,
+            ///<summary>
+            ///F2 key
+            ///</summary>
+            F2 = 0x71,
+            ///<summary>
+            ///F3 key
+            ///</summary>
+            F3 = 0x72,
+            ///<summary>
+            ///F4 key
+            ///</summary>
+            F4 = 0x73,
+            ///<summary>
+            ///F5 key
+            ///</summary>
+            F5 = 0x74,
+            ///<summary>
+            ///F6 key
+            ///</summary>
+            F6 = 0x75,
+            ///<summary>
+            ///F7 key
+            ///</summary>
+            F7 = 0x76,
+            ///<summary>
+            ///F8 key
+            ///</summary>
+            F8 = 0x77,
+            ///<summary>
+            ///F9 key
+            ///</summary>
+            F9 = 0x78,
+            ///<summary>
+            ///F10 key
+            ///</summary>
+            F10 = 0x79,
+            ///<summary>
+            ///F11 key
+            ///</summary>
+            F11 = 0x7A,
+            ///<summary>
+            ///F12 key
+            ///</summary>
+            F12 = 0x7B,
+            ///<summary>
+            ///F13 key
+            ///</summary>
+            F13 = 0x7C,
+            ///<summary>
+            ///F14 key
+            ///</summary>
+            F14 = 0x7D,
+            ///<summary>
+            ///F15 key
+            ///</summary>
+            F15 = 0x7E,
+            ///<summary>
+            ///F16 key
+            ///</summary>
+            F16 = 0x7F,
+            ///<summary>
+            ///F17 key  
+            ///</summary>
+            F17 = 0x80,
+            ///<summary>
+            ///F18 key  
+            ///</summary>
+            F18 = 0x81,
+            ///<summary>
+            ///F19 key  
+            ///</summary>
+            F19 = 0x82,
+            ///<summary>
+            ///F20 key  
+            ///</summary>
+            F20 = 0x83,
+            ///<summary>
+            ///F21 key  
+            ///</summary>
+            F21 = 0x84,
+            ///<summary>
+            ///F22 key, (PPC only) Key used to lock device.
+            ///</summary>
+            F22 = 0x85,
+            ///<summary>
+            ///F23 key  
+            ///</summary>
+            F23 = 0x86,
+            ///<summary>
+            ///F24 key  
+            ///</summary>
+            F24 = 0x87,
+            ///<summary>
+            ///NUM LOCK key
+            ///</summary>
+            NUMLOCK = 0x90,
+            ///<summary>
+            ///SCROLL LOCK key
+            ///</summary>
+            SCROLL = 0x91,
+            ///<summary>
+            ///Left SHIFT key
+            ///</summary>
+            LSHIFT = 0xA0,
+            ///<summary>
+            ///Right SHIFT key
+            ///</summary>
+            RSHIFT = 0xA1,
+            ///<summary>
+            ///Left CONTROL key
+            ///</summary>
+            LCONTROL = 0xA2,
+            ///<summary>
+            ///Right CONTROL key
+            ///</summary>
+            RCONTROL = 0xA3,
+            ///<summary>
+            ///Left MENU key
+            ///</summary>
+            LMENU = 0xA4,
+            ///<summary>
+            ///Right MENU key
+            ///</summary>
+            RMENU = 0xA5,
+            ///<summary>
+            ///Windows 2000/XP: Browser Back key
+            ///</summary>
+            BROWSER_BACK = 0xA6,
+            ///<summary>
+            ///Windows 2000/XP: Browser Forward key
+            ///</summary>
+            BROWSER_FORWARD = 0xA7,
+            ///<summary>
+            ///Windows 2000/XP: Browser Refresh key
+            ///</summary>
+            BROWSER_REFRESH = 0xA8,
+            ///<summary>
+            ///Windows 2000/XP: Browser Stop key
+            ///</summary>
+            BROWSER_STOP = 0xA9,
+            ///<summary>
+            ///Windows 2000/XP: Browser Search key
+            ///</summary>
+            BROWSER_SEARCH = 0xAA,
+            ///<summary>
+            ///Windows 2000/XP: Browser Favorites key
+            ///</summary>
+            BROWSER_FAVORITES = 0xAB,
+            ///<summary>
+            ///Windows 2000/XP: Browser Start and Home key
+            ///</summary>
+            BROWSER_HOME = 0xAC,
+            ///<summary>
+            ///Windows 2000/XP: Volume Mute key
+            ///</summary>
+            VOLUME_MUTE = 0xAD,
+            ///<summary>
+            ///Windows 2000/XP: Volume Down key
+            ///</summary>
+            VOLUME_DOWN = 0xAE,
+            ///<summary>
+            ///Windows 2000/XP: Volume Up key
+            ///</summary>
+            VOLUME_UP = 0xAF,
+            ///<summary>
+            ///Windows 2000/XP: Next Track key
+            ///</summary>
+            MEDIA_NEXT_TRACK = 0xB0,
+            ///<summary>
+            ///Windows 2000/XP: Previous Track key
+            ///</summary>
+            MEDIA_PREV_TRACK = 0xB1,
+            ///<summary>
+            ///Windows 2000/XP: Stop Media key
+            ///</summary>
+            MEDIA_STOP = 0xB2,
+            ///<summary>
+            ///Windows 2000/XP: Play/Pause Media key
+            ///</summary>
+            MEDIA_PLAY_PAUSE = 0xB3,
+            ///<summary>
+            ///Windows 2000/XP: Start Mail key
+            ///</summary>
+            LAUNCH_MAIL = 0xB4,
+            ///<summary>
+            ///Windows 2000/XP: Select Media key
+            ///</summary>
+            LAUNCH_MEDIA_SELECT = 0xB5,
+            ///<summary>
+            ///Windows 2000/XP: Start Application 1 key
+            ///</summary>
+            LAUNCH_APP1 = 0xB6,
+            ///<summary>
+            ///Windows 2000/XP: Start Application 2 key
+            ///</summary>
+            LAUNCH_APP2 = 0xB7,
+            ///<summary>
+            ///Used for miscellaneous characters; it can vary by keyboard.
+            ///</summary>
+            OEM_1 = 0xBA,
+            ///<summary>
+            ///Windows 2000/XP: For any country/region, the '+' key
+            ///</summary>
+            OEM_PLUS = 0xBB,
+            ///<summary>
+            ///Windows 2000/XP: For any country/region, the ',' key
+            ///</summary>
+            OEM_COMMA = 0xBC,
+            ///<summary>
+            ///Windows 2000/XP: For any country/region, the '-' key
+            ///</summary>
+            OEM_MINUS = 0xBD,
+            ///<summary>
+            ///Windows 2000/XP: For any country/region, the '.' key
+            ///</summary>
+            OEM_PERIOD = 0xBE,
+            ///<summary>
+            ///Used for miscellaneous characters; it can vary by keyboard.
+            ///</summary>
+            OEM_2 = 0xBF,
+            ///<summary>
+            ///Used for miscellaneous characters; it can vary by keyboard.
+            ///</summary>
+            OEM_3 = 0xC0,
+            ///<summary>
+            ///Used for miscellaneous characters; it can vary by keyboard.
+            ///</summary>
+            OEM_4 = 0xDB,
+            ///<summary>
+            ///Used for miscellaneous characters; it can vary by keyboard.
+            ///</summary>
+            OEM_5 = 0xDC,
+            ///<summary>
+            ///Used for miscellaneous characters; it can vary by keyboard.
+            ///</summary>
+            OEM_6 = 0xDD,
+            ///<summary>
+            ///Used for miscellaneous characters; it can vary by keyboard.
+            ///</summary>
+            OEM_7 = 0xDE,
+            ///<summary>
+            ///Used for miscellaneous characters; it can vary by keyboard.
+            ///</summary>
+            OEM_8 = 0xDF,
+            ///<summary>
+            ///Windows 2000/XP: Either the angle bracket key or the backslash key on the RT 102-key keyboard
+            ///</summary>
+            OEM_102 = 0xE2,
+            ///<summary>
+            ///Windows 95/98/Me, Windows NT 4.0, Windows 2000/XP: IME PROCESS key
+            ///</summary>
+            PROCESSKEY = 0xE5,
+            ///<summary>
+            ///Windows 2000/XP: Used to pass Unicode characters as if they were keystrokes.
+            ///The VK_PACKET key is the low word of a 32-bit Virtual Key value used for non-keyboard input methods. For more information,
+            ///see Remark in KEYBDINPUT, SendInput, WM_KEYDOWN, and WM_KEYUP
+            ///</summary>
+            PACKET = 0xE7,
+            ///<summary>
+            ///Attn key
+            ///</summary>
+            ATTN = 0xF6,
+            ///<summary>
+            ///CrSel key
+            ///</summary>
+            CRSEL = 0xF7,
+            ///<summary>
+            ///ExSel key
+            ///</summary>
+            EXSEL = 0xF8,
+            ///<summary>
+            ///Erase EOF key
+            ///</summary>
+            EREOF = 0xF9,
+            ///<summary>
+            ///Play key
+            ///</summary>
+            PLAY = 0xFA,
+            ///<summary>
+            ///Zoom key
+            ///</summary>
+            ZOOM = 0xFB,
+            ///<summary>
+            ///Reserved
+            ///</summary>
+            NONAME = 0xFC,
+            ///<summary>
+            ///PA1 key
+            ///</summary>
+            PA1 = 0xFD,
+            ///<summary>
+            ///Clear key
+            ///</summary>
+            OEM_CLEAR = 0xFE
+        }
+        internal enum ScanCodeShort : short
+        {
+            LBUTTON = 0,
+            RBUTTON = 0,
+            CANCEL = 70,
+            MBUTTON = 0,
+            XBUTTON1 = 0,
+            XBUTTON2 = 0,
+            BACK = 14,
+            TAB = 15,
+            CLEAR = 76,
+            RETURN = 28,
+            SHIFT = 42,
+            CONTROL = 29,
+            MENU = 56,
+            PAUSE = 0,
+            CAPITAL = 58,
+            KANA = 0,
+            HANGUL = 0,
+            JUNJA = 0,
+            FINAL = 0,
+            HANJA = 0,
+            KANJI = 0,
+            ESCAPE = 1,
+            CONVERT = 0,
+            NONCONVERT = 0,
+            ACCEPT = 0,
+            MODECHANGE = 0,
+            SPACE = 57,
+            PRIOR = 73,
+            NEXT = 81,
+            END = 79,
+            HOME = 71,
+            LEFT = 75,
+            UP = 72,
+            RIGHT = 77,
+            DOWN = 80,
+            SELECT = 0,
+            PRINT = 0,
+            EXECUTE = 0,
+            SNAPSHOT = 84,
+            INSERT = 82,
+            DELETE = 83,
+            HELP = 99,
+            KEY_0 = 11,
+            KEY_1 = 2,
+            KEY_2 = 3,
+            KEY_3 = 4,
+            KEY_4 = 5,
+            KEY_5 = 6,
+            KEY_6 = 7,
+            KEY_7 = 8,
+            KEY_8 = 9,
+            KEY_9 = 10,
+            KEY_A = 30,
+            KEY_B = 48,
+            KEY_C = 46,
+            KEY_D = 32,
+            KEY_E = 18,
+            KEY_F = 33,
+            KEY_G = 34,
+            KEY_H = 35,
+            KEY_I = 23,
+            KEY_J = 36,
+            KEY_K = 37,
+            KEY_L = 38,
+            KEY_M = 50,
+            KEY_N = 49,
+            KEY_O = 24,
+            KEY_P = 25,
+            KEY_Q = 16,
+            KEY_R = 19,
+            KEY_S = 31,
+            KEY_T = 20,
+            KEY_U = 22,
+            KEY_V = 47,
+            KEY_W = 17,
+            KEY_X = 45,
+            KEY_Y = 21,
+            KEY_Z = 44,
+            LWIN = 91,
+            RWIN = 92,
+            APPS = 93,
+            SLEEP = 95,
+            NUMPAD0 = 82,
+            NUMPAD1 = 79,
+            NUMPAD2 = 80,
+            NUMPAD3 = 81,
+            NUMPAD4 = 75,
+            NUMPAD5 = 76,
+            NUMPAD6 = 77,
+            NUMPAD7 = 71,
+            NUMPAD8 = 72,
+            NUMPAD9 = 73,
+            MULTIPLY = 55,
+            ADD = 78,
+            SEPARATOR = 0,
+            SUBTRACT = 74,
+            DECIMAL = 83,
+            DIVIDE = 53,
+            F1 = 59,
+            F2 = 60,
+            F3 = 61,
+            F4 = 62,
+            F5 = 63,
+            F6 = 64,
+            F7 = 65,
+            F8 = 66,
+            F9 = 67,
+            F10 = 68,
+            F11 = 87,
+            F12 = 88,
+            F13 = 100,
+            F14 = 101,
+            F15 = 102,
+            F16 = 103,
+            F17 = 104,
+            F18 = 105,
+            F19 = 106,
+            F20 = 107,
+            F21 = 108,
+            F22 = 109,
+            F23 = 110,
+            F24 = 118,
+            NUMLOCK = 69,
+            SCROLL = 70,
+            LSHIFT = 42,
+            RSHIFT = 54,
+            LCONTROL = 29,
+            RCONTROL = 29,
+            LMENU = 56,
+            RMENU = 56,
+            BROWSER_BACK = 106,
+            BROWSER_FORWARD = 105,
+            BROWSER_REFRESH = 103,
+            BROWSER_STOP = 104,
+            BROWSER_SEARCH = 101,
+            BROWSER_FAVORITES = 102,
+            BROWSER_HOME = 50,
+            VOLUME_MUTE = 32,
+            VOLUME_DOWN = 46,
+            VOLUME_UP = 48,
+            MEDIA_NEXT_TRACK = 25,
+            MEDIA_PREV_TRACK = 16,
+            MEDIA_STOP = 36,
+            MEDIA_PLAY_PAUSE = 34,
+            LAUNCH_MAIL = 108,
+            LAUNCH_MEDIA_SELECT = 109,
+            LAUNCH_APP1 = 107,
+            LAUNCH_APP2 = 33,
+            OEM_1 = 39,
+            OEM_PLUS = 13,
+            OEM_COMMA = 51,
+            OEM_MINUS = 12,
+            OEM_PERIOD = 52,
+            OEM_2 = 53,
+            OEM_3 = 41,
+            OEM_4 = 26,
+            OEM_5 = 43,
+            OEM_6 = 27,
+            OEM_7 = 40,
+            OEM_8 = 0,
+            OEM_102 = 86,
+            PROCESSKEY = 0,
+            PACKET = 0,
+            ATTN = 0,
+            CRSEL = 0,
+            EXSEL = 0,
+            EREOF = 93,
+            PLAY = 0,
+            ZOOM = 98,
+            NONAME = 0,
+            PA1 = 0,
+            OEM_CLEAR = 0,
+        }
+    }
+}

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/Functions/Inputs.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/Functions/Inputs.cs
@@ -15,9 +15,9 @@ namespace HASS.Agent.Shared.Functions
         [StructLayout(LayoutKind.Sequential)]
         public struct INPUT
         {
-            internal InputType type;
-            internal InputUnion U;
-            internal static int Size
+            public InputType type;
+            public InputUnion U;
+            public static int Size
             {
                 get { return Marshal.SizeOf(typeof(INPUT)); }
             }
@@ -34,22 +34,22 @@ namespace HASS.Agent.Shared.Functions
         public struct InputUnion
         {
             [FieldOffset(0)]
-            internal MOUSEINPUT mi;
+            public MOUSEINPUT mi;
             [FieldOffset(0)]
-            internal KEYBDINPUT ki;
+            public KEYBDINPUT ki;
             [FieldOffset(0)]
-            internal HARDWAREINPUT hi;
+            public HARDWAREINPUT hi;
         }
 
         [StructLayout(LayoutKind.Sequential)]
         public struct MOUSEINPUT
         {
-            internal int dx;
-            internal int dy;
-            internal int mouseData;
-            internal MOUSEEVENTF dwFlags;
-            internal uint time;
-            internal UIntPtr dwExtraInfo;
+            public int dx;
+            public int dy;
+            public int mouseData;
+            public MOUSEEVENTF dwFlags;
+            public uint time;
+            public UIntPtr dwExtraInfo;
         }
 
         [Flags]
@@ -74,11 +74,11 @@ namespace HASS.Agent.Shared.Functions
         [StructLayout(LayoutKind.Sequential)]
         public struct KEYBDINPUT
         {
-            internal VirtualKeyShort wVk;
-            internal ScanCodeShort wScan;
-            internal KEYEVENTF dwFlags;
-            internal int time;
-            internal UIntPtr dwExtraInfo;
+            public VirtualKeyShort wVk;
+            public ScanCodeShort wScan;
+            public KEYEVENTF dwFlags;
+            public int time;
+            public UIntPtr dwExtraInfo;
         }
 
         [Flags]
@@ -791,7 +791,7 @@ namespace HASS.Agent.Shared.Functions
             ///</summary>
             OEM_CLEAR = 0xFE
         }
-        internal enum ScanCodeShort : short
+        public enum ScanCodeShort : short
         {
             LBUTTON = 0,
             RBUTTON = 0,

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/Functions/NativeMethods.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/Functions/NativeMethods.cs
@@ -10,9 +10,9 @@ using static HASS.Agent.Shared.Functions.Inputs;
 namespace HASS.Agent.Shared.Functions
 {
     [SuppressMessage("ReSharper", "InconsistentNaming")]
-    internal static class NativeMethods
+    public static class NativeMethods
     {
-        internal static WINDOWPLACEMENT GetPlacement(IntPtr hwnd)
+        public static WINDOWPLACEMENT GetPlacement(IntPtr hwnd)
         {
             var placement = new WINDOWPLACEMENT();
             placement.length = Marshal.SizeOf(placement);
@@ -22,11 +22,11 @@ namespace HASS.Agent.Shared.Functions
 
         [DllImport("user32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool GetWindowPlacement(IntPtr hWnd, ref WINDOWPLACEMENT lpwndpl);
+        public static extern bool GetWindowPlacement(IntPtr hWnd, ref WINDOWPLACEMENT lpwndpl);
 
         [Serializable]
         [StructLayout(LayoutKind.Sequential)]
-        internal struct WINDOWPLACEMENT
+        public struct WINDOWPLACEMENT
         {
             public int length;
             public int flags;
@@ -41,36 +41,36 @@ namespace HASS.Agent.Shared.Functions
         internal const uint SC_MONITORPOWER = 0xF170;
 
         [DllImport("advapi32.dll", SetLastError = true)]
-        internal static extern bool OpenProcessToken(IntPtr processHandle, uint desiredAccess, out IntPtr tokenHandle);
+        public static extern bool OpenProcessToken(IntPtr processHandle, uint desiredAccess, out IntPtr tokenHandle);
 
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool CloseHandle(IntPtr hObject);
+        public static extern bool CloseHandle(IntPtr hObject);
 
-        internal delegate bool EnumWindowsProc(IntPtr hWnd, int lParam);
-
-        [DllImport("USER32.DLL")]
-        internal static extern bool EnumWindows(EnumWindowsProc enumFunc, int lParam);
+        public delegate bool EnumWindowsProc(IntPtr hWnd, int lParam);
 
         [DllImport("USER32.DLL")]
-        internal static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+        public static extern bool EnumWindows(EnumWindowsProc enumFunc, int lParam);
 
         [DllImport("USER32.DLL")]
-        internal static extern int GetWindowTextLength(IntPtr hWnd);
+        public static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
 
         [DllImport("USER32.DLL")]
-        internal static extern bool IsWindowVisible(IntPtr hWnd);
+        public static extern int GetWindowTextLength(IntPtr hWnd);
 
         [DllImport("USER32.DLL")]
-        internal static extern IntPtr GetShellWindow();
+        public static extern bool IsWindowVisible(IntPtr hWnd);
+
+        [DllImport("USER32.DLL")]
+        public static extern IntPtr GetShellWindow();
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        internal static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, [Out] IntPtr lParam);
+        public static extern IntPtr SendMessage(IntPtr hWnd, uint Msg, IntPtr wParam, [Out] IntPtr lParam);
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        internal static extern IntPtr PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, [Out] IntPtr lParam);
+        public static extern IntPtr PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, [Out] IntPtr lParam);
 
         [DllImport("user32.dll")]
-        internal static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+        public static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/Functions/NativeMethods.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/Functions/NativeMethods.cs
@@ -68,5 +68,94 @@ namespace HASS.Agent.Shared.Functions
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         internal static extern IntPtr PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, [Out] IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        internal static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct INPUT
+        {
+            internal InputType type;
+            internal InputUnion U;
+            internal static int Size
+            {
+                get { return Marshal.SizeOf(typeof(INPUT)); }
+            }
+        }
+
+        public enum InputType : uint
+        {
+            INPUT_MOUSE,
+            INPUT_KEYBOARD,
+            INPUT_HARDWARE
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        public struct InputUnion
+        {
+            [FieldOffset(0)]
+            internal MOUSEINPUT mi;
+            [FieldOffset(0)]
+            internal KEYBDINPUT ki;
+            [FieldOffset(0)]
+            internal HARDWAREINPUT hi;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct MOUSEINPUT
+        {
+            internal int dx;
+            internal int dy;
+            internal int mouseData;
+            internal MOUSEEVENTF dwFlags;
+            internal uint time;
+            internal UIntPtr dwExtraInfo;
+        }
+
+        [Flags]
+        public enum MOUSEEVENTF : uint
+        {
+            ABSOLUTE = 0x8000,
+            HWHEEL = 0x01000,
+            MOVE = 0x0001,
+            MOVE_NOCOALESCE = 0x2000,
+            LEFTDOWN = 0x0002,
+            LEFTUP = 0x0004,
+            RIGHTDOWN = 0x0008,
+            RIGHTUP = 0x0010,
+            MIDDLEDOWN = 0x0020,
+            MIDDLEUP = 0x0040,
+            VIRTUALDESK = 0x4000,
+            WHEEL = 0x0800,
+            XDOWN = 0x0080,
+            XUP = 0x0100
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct KEYBDINPUT
+        {
+            internal short wVk;
+            internal short wScan;
+            internal KEYEVENTF dwFlags;
+            internal int time;
+            internal UIntPtr dwExtraInfo;
+        }
+
+        [Flags]
+        public enum KEYEVENTF : uint
+        {
+            EXTENDEDKEY = 0x0001,
+            KEYUP = 0x0002,
+            SCANCODE = 0x0008,
+            UNICODE = 0x0004
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct HARDWAREINPUT
+        {
+            internal int uMsg;
+            internal short wParamL;
+            internal short wParamH;
+        }
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/Functions/NativeMethods.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/Functions/NativeMethods.cs
@@ -5,6 +5,7 @@ using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Text;
 using HASS.Agent.Shared.Enums;
+using static HASS.Agent.Shared.Functions.Inputs;
 
 namespace HASS.Agent.Shared.Functions
 {
@@ -71,91 +72,5 @@ namespace HASS.Agent.Shared.Functions
 
         [DllImport("user32.dll")]
         internal static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct INPUT
-        {
-            internal InputType type;
-            internal InputUnion U;
-            internal static int Size
-            {
-                get { return Marshal.SizeOf(typeof(INPUT)); }
-            }
-        }
-
-        public enum InputType : uint
-        {
-            INPUT_MOUSE,
-            INPUT_KEYBOARD,
-            INPUT_HARDWARE
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        public struct InputUnion
-        {
-            [FieldOffset(0)]
-            internal MOUSEINPUT mi;
-            [FieldOffset(0)]
-            internal KEYBDINPUT ki;
-            [FieldOffset(0)]
-            internal HARDWAREINPUT hi;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct MOUSEINPUT
-        {
-            internal int dx;
-            internal int dy;
-            internal int mouseData;
-            internal MOUSEEVENTF dwFlags;
-            internal uint time;
-            internal UIntPtr dwExtraInfo;
-        }
-
-        [Flags]
-        public enum MOUSEEVENTF : uint
-        {
-            ABSOLUTE = 0x8000,
-            HWHEEL = 0x01000,
-            MOVE = 0x0001,
-            MOVE_NOCOALESCE = 0x2000,
-            LEFTDOWN = 0x0002,
-            LEFTUP = 0x0004,
-            RIGHTDOWN = 0x0008,
-            RIGHTUP = 0x0010,
-            MIDDLEDOWN = 0x0020,
-            MIDDLEUP = 0x0040,
-            VIRTUALDESK = 0x4000,
-            WHEEL = 0x0800,
-            XDOWN = 0x0080,
-            XUP = 0x0100
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct KEYBDINPUT
-        {
-            internal short wVk;
-            internal short wScan;
-            internal KEYEVENTF dwFlags;
-            internal int time;
-            internal UIntPtr dwExtraInfo;
-        }
-
-        [Flags]
-        public enum KEYEVENTF : uint
-        {
-            EXTENDEDKEY = 0x0001,
-            KEYUP = 0x0002,
-            SCANCODE = 0x0008,
-            UNICODE = 0x0004
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        public struct HARDWAREINPUT
-        {
-            internal int uMsg;
-            internal short wParamL;
-            internal short wParamH;
-        }
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommand.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommand.cs
@@ -5,6 +5,7 @@ using System.Windows.Forms;
 using HASS.Agent.Shared.Enums;
 using HASS.Agent.Shared.Models.HomeAssistant;
 using Serilog;
+using static HASS.Agent.Shared.Functions.Inputs;
 using static HASS.Agent.Shared.Functions.NativeMethods;
 
 namespace HASS.Agent.Shared.HomeAssistant.Commands
@@ -17,18 +18,11 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
     {
         private const string DefaultName = "key";
 
-        public const int VK_MEDIA_NEXT_TRACK = 0xB0; //todo: fix
-        public const int VK_MEDIA_PLAY_PAUSE = 0xB3; //todo: fix
-        public const int VK_MEDIA_PREV_TRACK = 0xB1; //todo: fix
-        public const int VK_VOLUME_MUTE = 0xAD; //todo: fix
-        public const int VK_VOLUME_UP = 0xAF; //todo: fix
-        public const int VK_VOLUME_DOWN = 0xAE; //todo: fix
-        public const int KEY_UP = 38;  //todo: fix
-
         public string State { get; protected set; }
-        public byte KeyCode { get; set; }
+        
+        public VirtualKeyShort KeyCode { get; set; }
 
-        public KeyCommand(byte keyCode, string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, entityType, id)
+        public KeyCommand(VirtualKeyShort keyCode, string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(name ?? DefaultName, friendlyName ?? null, entityType, id)
         {
             KeyCode = keyCode;
             State = "OFF";

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaMuteCommand.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaMuteCommand.cs
@@ -1,4 +1,5 @@
 ﻿using HASS.Agent.Shared.Enums;
+using static HASS.Agent.Shared.Functions.Inputs;
 
 namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
 {
@@ -9,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "mute";
 
-        public MediaMuteCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VK_VOLUME_MUTE, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MediaMuteCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.VOLUME_MUTE, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaNextCommand.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaNextCommand.cs
@@ -1,4 +1,5 @@
 ﻿using HASS.Agent.Shared.Enums;
+using static HASS.Agent.Shared.Functions.Inputs;
 
 namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
 {
@@ -9,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "next";
 
-        public MediaNextCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VK_MEDIA_NEXT_TRACK, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MediaNextCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.MEDIA_NEXT_TRACK, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaPlayPauseCommand.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaPlayPauseCommand.cs
@@ -1,4 +1,5 @@
 ﻿using HASS.Agent.Shared.Enums;
+using static HASS.Agent.Shared.Functions.Inputs;
 
 namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
 {
@@ -9,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "playpause";
 
-        public MediaPlayPauseCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VK_MEDIA_PLAY_PAUSE, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MediaPlayPauseCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.MEDIA_PLAY_PAUSE, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaPreviousCommand.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaPreviousCommand.cs
@@ -1,4 +1,5 @@
 ﻿using HASS.Agent.Shared.Enums;
+using static HASS.Agent.Shared.Functions.Inputs;
 
 namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
 {
@@ -9,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "previous";
 
-        public MediaPreviousCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VK_MEDIA_PREV_TRACK, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MediaPreviousCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.MEDIA_PREV_TRACK, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaVolumeDownCommand.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaVolumeDownCommand.cs
@@ -1,4 +1,5 @@
 ﻿using HASS.Agent.Shared.Enums;
+using static HASS.Agent.Shared.Functions.Inputs;
 
 namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
 {
@@ -9,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "volumedown";
 
-        public MediaVolumeDownCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VK_VOLUME_DOWN, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MediaVolumeDownCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.VOLUME_DOWN, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaVolumeUpCommand.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MediaVolumeUpCommand.cs
@@ -1,4 +1,5 @@
 ﻿using HASS.Agent.Shared.Enums;
+using static HASS.Agent.Shared.Functions.Inputs;
 
 namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
 {
@@ -9,6 +10,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "volumeup";
 
-        public MediaVolumeUpCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VK_VOLUME_UP, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MediaVolumeUpCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Switch, string id = default) : base(VirtualKeyShort.VOLUME_UP, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MonitorWakeCommand.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/KeyCommands/MonitorWakeCommand.cs
@@ -1,4 +1,5 @@
 ﻿using HASS.Agent.Shared.Enums;
+using static HASS.Agent.Shared.Functions.Inputs;
 
 namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
 {
@@ -10,6 +11,6 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands.KeyCommands
     {
         private const string DefaultName = "monitorwake";
 
-        public MonitorWakeCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Button, string id = default) : base(KEY_UP, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
+        public MonitorWakeCommand(string name = DefaultName, string friendlyName = DefaultName, CommandEntityType entityType = CommandEntityType.Button, string id = default) : base(VirtualKeyShort.UP, name ?? DefaultName, friendlyName ?? null, entityType, id) { }
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/Models/Config/ConfiguredCommand.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/Models/Config/ConfiguredCommand.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using HASS.Agent.Shared.Enums;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using static HASS.Agent.Shared.Functions.Inputs;
 
 namespace HASS.Agent.Shared.Models.Config
 {
@@ -23,7 +24,7 @@ namespace HASS.Agent.Shared.Models.Config
 
         public string Command { get; set; } = string.Empty;
 
-        public byte KeyCode { get; set; }
+        public VirtualKeyShort KeyCode { get; set; }
         public bool RunAsLowIntegrity { get; set; } = false;
         public List<string> Keys { get; set; } = new List<string>();
     }

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/Commands/CommandsMod.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/Commands/CommandsMod.cs
@@ -13,6 +13,7 @@ using HASS.Agent.Shared.Functions;
 using HASS.Agent.Shared.Models.Config;
 using HASS.Agent.Shared.Models.Internal;
 using Newtonsoft.Json;
+using static HASS.Agent.Shared.Functions.Inputs;
 
 namespace HASS.Agent.Forms.Commands
 {
@@ -309,14 +310,14 @@ namespace HASS.Agent.Forms.Commands
                         ActiveControl = TbKeyCode;
                         return;
                     }
-                    var parsed = int.TryParse(keycodeStr, out var keycode);
+                    var parsed = short.TryParse(keycodeStr, out var keycode);
                     if (!parsed)
                     {
                         MessageBoxAdv.Show(this, Languages.CommandsMod_BtnStore_MessageBox9, Variables.MessageBoxTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         ActiveControl = TbKeyCode;
                         return;
                     }
-                    Command.KeyCode = (byte)keycode;
+                    Command.KeyCode = (VirtualKeyShort)keycode;
                     break;
 
                 case CommandType.MultipleKeysCommand:

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/Commands/CommandsMod.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/Commands/CommandsMod.cs
@@ -14,6 +14,7 @@ using HASS.Agent.Shared.Models.Config;
 using HASS.Agent.Shared.Models.Internal;
 using Newtonsoft.Json;
 using static HASS.Agent.Shared.Functions.Inputs;
+using Mono.Unix.Native;
 
 namespace HASS.Agent.Forms.Commands
 {
@@ -121,7 +122,7 @@ namespace HASS.Agent.Forms.Commands
         {
             // load the card
             var commandCard = CommandsManager.CommandInfoCards[Command.Type];
-            
+
             // select it as well
             foreach (ListViewItem lvi in LvCommands.Items)
             {
@@ -310,14 +311,15 @@ namespace HASS.Agent.Forms.Commands
                         ActiveControl = TbKeyCode;
                         return;
                     }
-                    var parsed = short.TryParse(keycodeStr, out var keycode);
+
+                    var parsed = Enum.TryParse(keycodeStr, out VirtualKeyShort enumKeycode);
                     if (!parsed)
                     {
                         MessageBoxAdv.Show(this, Languages.CommandsMod_BtnStore_MessageBox9, Variables.MessageBoxTitle, MessageBoxButtons.OK, MessageBoxIcon.Error);
                         ActiveControl = TbKeyCode;
                         return;
                     }
-                    Command.KeyCode = (VirtualKeyShort)keycode;
+                    Command.KeyCode = enumKeycode;
                     break;
 
                 case CommandType.MultipleKeysCommand:
@@ -437,7 +439,7 @@ namespace HASS.Agent.Forms.Commands
             // done
             DialogResult = DialogResult.OK;
         }
-        
+
         private void LvCommands_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (_loading) return;
@@ -631,7 +633,7 @@ namespace HASS.Agent.Forms.Commands
 
                 TbSetting.Text = string.Empty;
                 TbSetting.Visible = true;
-                
+
                 CbCommandSpecific.CheckState = CheckState.Unchecked;
                 CbCommandSpecific.Text = Languages.CommandsMod_CbCommandSpecific_Incognito;
 
@@ -882,7 +884,7 @@ namespace HASS.Agent.Forms.Commands
 
             var item = (KeyValuePair<int, string>)CbEntityType.SelectedItem;
             var entityType = (CommandEntityType)item.Key;
-            
+
             var deviceConfig = Variables.MqttManager?.GetDeviceConfigModel();
             if (deviceConfig == null)
             {
@@ -936,7 +938,7 @@ namespace HASS.Agent.Forms.Commands
 
         private void TbKeyCode_KeyDown(object sender, KeyEventArgs e)
         {
-            TbKeyCode.Text = e.KeyValue.ToString();
+            TbKeyCode.Text = Enum.GetName(typeof(VirtualKeyShort), e.KeyValue);
         }
     }
 }

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/Main.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/Main.cs
@@ -21,6 +21,7 @@ using HASS.Agent.Shared.Functions;
 using Serilog;
 using Syncfusion.Windows.Forms;
 using WK.Libraries.HotkeyListenerNS;
+using NativeMethods = HASS.Agent.Functions.NativeMethods;
 using QuickActionsConfig = HASS.Agent.Forms.QuickActions.QuickActionsConfig;
 using Task = System.Threading.Tasks.Task;
 

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.de.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.de.resx
@@ -1352,9 +1352,10 @@ Dein Befehl wird als Argument so wie er ist bereitgestellt, sodass du selbst Anf
   <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
     <value>Simuliert einen einzelnen Tastendruck.
 
-Du kannst jeden dieser werte wählen: https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes 
+Klicken Sie auf das Textfeld „Tastencode“ und drücken Sie die Taste, die Sie simulieren möchten. Der entsprechende Schlüsselcode wird für Sie eingegeben.
+Für die TAB-Taste verwenden Sie bitte LCTRL+TAB.
 
-Falls du weitere Tasten benötigst und/oder Modifizierungen wie STRG benötigst, dann benutze den MultipleTasten Befehl.</value>
+Wenn Sie weitere Tasten und/oder Modifikatoren wie STRG benötigen, verwenden Sie den Befehl MultipleKeys.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
@@ -2732,7 +2733,7 @@ Stelle sicher, dass keine andere Instanz von HASS.Agent läuft und der Port verf
 
 Dies unterscheidet sich von dem „ÖffneUrl“ Befehl, da er keinen vollständigen Browser lädt, sondern nur die bereitgestellte URL in einem eigenen Fenster.
 
-Du kannst dies benutzen, um zum Beispiel schnell Home Assistant&apos;s Dashboard anzuzeigen.
+Du kannst dies benutzen, um zum Beispiel schnell Home Assistant's Dashboard anzuzeigen.
 
 Standardmäßig werden alle Cookies für unbegrenzte Zeit gespeichert, sodass du dich nur einmal einloggen musst.</value>
   </data>
@@ -2793,7 +2794,7 @@ Hinweis: Diese Meldung wird nur einmal angezeigt.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigLocalApi_LblInfo2" xml:space="preserve">
-    <value>Um auf Anfragen reagieren zu können, muss HASS.Agent&apos;s Port in deiner Firewall reserviert und geöffnet werden. Du kannst diese Schaltfläche verwenden, um dies für dich zu erledigen.</value>
+    <value>Um auf Anfragen reagieren zu können, muss HASS.Agent's Port in deiner Firewall reserviert und geöffnet werden. Du kannst diese Schaltfläche verwenden, um dies für dich zu erledigen.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigLocalApi_LblPort" xml:space="preserve">
@@ -3170,13 +3171,13 @@ Es sollte drei Abschnitte enthalten (getrennt durch zwei Punkte).
 Sind Sie sicher, dass Sie es so verwenden wollen?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
-    <value>Die URI Ihres Home-Assistenten sieht nicht richtig aus. Sie sollte etwa so aussehen: &quot;http://homeassistant.local:8123&quot; oder &quot;https://192.168.0.1:8123&quot;.
+    <value>Die URI Ihres Home-Assistenten sieht nicht richtig aus. Sie sollte etwa so aussehen: "http://homeassistant.local:8123" oder "https://192.168.0.1:8123".
 
 Sind Sie sicher, dass Sie ihn so verwenden wollen?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
     <value>Deine MQTT Broker URI sieht nicht richtig aus. So sollte es aussehen
-&quot;homeassistant.local&quot; oder &quot;192.168.0.1&quot;
+"homeassistant.local" oder "192.168.0.1"
 
 Bist Du sicher, es so zu verwenden?</value>
   </data>
@@ -3333,7 +3334,7 @@ Möchtest Du den Protokollordner öffnen?</value>
     <value>Fehler beim Einstellen des Startmodus, überprüfe die Protokolle</value>
   </data>
   <data name="WebView_InitializeAsync_MessageBox1" xml:space="preserve">
-    <value>Microsoft&apos;s WebView2 Runtime wurde nicht auf diesem Gerät gefunden. Normalerweise wird dies vom Installer ausgeführt, Du kannst es auch manuell installieren.
+    <value>Microsoft's WebView2 Runtime wurde nicht auf diesem Gerät gefunden. Normalerweise wird dies vom Installer ausgeführt, Du kannst es auch manuell installieren.
 
 Willst Du den Runtime Installer herunterladen?</value>
   </data>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.en.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.en.resx
@@ -811,10 +811,10 @@ you can probably use the preset address.</value>
     <value>Description</value>
   </data>
   <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
-    <value>&amp;Run as &apos;Low Integrity&apos;</value>
+    <value>&amp;Run as 'Low Integrity'</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
-    <value>What&apos;s this?</value>
+    <value>What's this?</value>
   </data>
   <data name="CommandsMod_ClmSensorName" xml:space="preserve">
     <value>  Type</value>
@@ -1214,7 +1214,7 @@ report bugs or get involved in general chit-chat!</value>
     <value>Fetching info, please wait..</value>
   </data>
   <data name="UpdatePending_LblNewReleaseInfo" xml:space="preserve">
-    <value>There&apos;s a new release available:</value>
+    <value>There's a new release available:</value>
   </data>
   <data name="UpdatePending_LblInfo1" xml:space="preserve">
     <value>Release notes</value>
@@ -1247,6 +1247,7 @@ Your command is provided as an argument 'as is', so you have to supply your own 
 	  <value>Simulates a single keypress.
 
 Click on the 'keycode' textbox and press the key you want simulated. The corresponding keycode will be entered for you.
+For TAB key please use LCTRL+TAB.
 
 If you need more keys and/or modifiers like CTRL, use the MultipleKeys command.</value>
   </data>
@@ -1264,22 +1265,22 @@ If you just want a window with a specific URL (not an entire browser), use a 'We
     <value>Logs off the current session.</value>
   </data>
   <data name="CommandsManager_MediaMuteCommandDescription" xml:space="preserve">
-    <value>Simulates &apos;Mute&apos; key.</value>
+    <value>Simulates 'Mute' key.</value>
   </data>
   <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
-    <value>Simulates &apos;Media Next&apos; key.</value>
+    <value>Simulates 'Media Next' key.</value>
   </data>
   <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
-    <value>Simulates &apos;Media Pause/Play&apos; key.</value>
+    <value>Simulates 'Media Pause/Play' key.</value>
   </data>
   <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
-    <value>Simulates &apos;Media Previous&apos; key.</value>
+    <value>Simulates 'Media Previous' key.</value>
   </data>
   <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
-    <value>Simulates &apos;Volume Down&apos; key.</value>
+    <value>Simulates 'Volume Down' key.</value>
   </data>
   <data name="CommandsManager_MediaVolumeUpCommandDescription" xml:space="preserve">
-    <value>Simulates &apos;Volume Up&apos; key.</value>
+    <value>Simulates 'Volume Up' key.</value>
   </data>
   <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
 	  <value>Simulates pressing mulitple keys.
@@ -1328,7 +1329,7 @@ Note: due to a limitation in Windows, this only works if hibernation is disabled
 You can use something like NirCmd (http://www.nirsoft.net/utils/nircmd.html) to circumvent this.</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox1" xml:space="preserve">
-    <value>Please enter the location of your browser&apos;s binary! (.exe file)</value>
+    <value>Please enter the location of your browser's binary! (.exe file)</value>
   </data>
   <data name="ConfigExternalTools_ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox2" xml:space="preserve">
     <value>The browser binary provided could not be found, please ensure the path is correct and try again.</value>
@@ -1347,7 +1348,7 @@ Please check the logs for more information.</value>
     <value>Please enter a valid API key!</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox2" xml:space="preserve">
-    <value>Please enter a value for your Home Assistant&apos;s URI.</value>
+    <value>Please enter a value for your Home Assistant's URI.</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox3" xml:space="preserve">
 	  <value>Unable to connect, the following error was returned:
@@ -1462,7 +1463,7 @@ Check the HASS.Agent (not the service) logs for more information.</value>
     <value>Activating Start-on-Login..</value>
   </data>
   <data name="OnboardingStartup_Failed" xml:space="preserve">
-    <value>Something went wrong. You can try again, or skip to the next page and retry after HASS.Agent&apos;s restart.</value>
+    <value>Something went wrong. You can try again, or skip to the next page and retry after HASS.Agent's restart.</value>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin_2" xml:space="preserve">
     <value>Enable Start-on-Login</value>
@@ -1471,7 +1472,7 @@ Check the HASS.Agent (not the service) logs for more information.</value>
     <value>Please provide a valid API key.</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox2" xml:space="preserve">
-    <value>Please enter your Home Assistant&apos;s URI.</value>
+    <value>Please enter your Home Assistant's URI.</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox3" xml:space="preserve">
 	  <value>Unable to connect, the following error was returned:
@@ -1721,19 +1722,19 @@ Please configure an executor or your command will not run.</value>
     <value>This means it will only be able to save and modify files in certain locations,</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
-    <value>such as the &apos;%USERPROFILE%\AppData\LocalLow&apos; folder or</value>
+    <value>such as the '%USERPROFILE%\AppData\LocalLow' folder or</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
-    <value>the &apos;HKEY_CURRENT_USER\Software\AppDataLow&apos; registry key.</value>
+    <value>the 'HKEY_CURRENT_USER\Software\AppDataLow' registry key.</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
-    <value>You should test your command to make sure it&apos;s not influenced by this!</value>
+    <value>You should test your command to make sure it's not influenced by this!</value>
   </data>
   <data name="CommandsMod_SpecificClient" xml:space="preserve">
     <value>{0} only!</value>
   </data>
   <data name="CommandsMod_LblMqttTopic_MessageBox1" xml:space="preserve">
-    <value>The MQTT manager hasn&apos;t been configured properly, or hasn&apos;t yet completed its startup.</value>
+    <value>The MQTT manager hasn't been configured properly, or hasn't yet completed its startup.</value>
   </data>
   <data name="QuickActions_CheckHassManager_MessageBox1" xml:space="preserve">
     <value>Unable to fetch your entities because of missing config, please enter the required values in the config screen.</value>
@@ -1888,10 +1889,10 @@ Please check the logs and make a bug report on GitHub.</value>
     <value>Checking..</value>
   </data>
   <data name="Main_CheckForUpdate_MessageBox1" xml:space="preserve">
-    <value>You&apos;re running the latest version: {0}{1}</value>
+    <value>You're running the latest version: {0}{1}</value>
   </data>
   <data name="UpdatePending_NewBetaRelease" xml:space="preserve">
-    <value>There&apos;s a new BETA release available:</value>
+    <value>There's a new BETA release available:</value>
   </data>
   <data name="UpdatePending_Title_Beta" xml:space="preserve">
     <value>HASS.Agent BETA Update</value>
@@ -2088,7 +2089,7 @@ This will also contain users that aren't active. If you only want the current ac
 Note: if used in the satellite service, it won't detect userspace applications.</value>
   </data>
   <data name="SensorsManager_NamedWindowSensorDescription" xml:space="preserve">
-    <value>Provides an ON/OFF value based on whether the window is currently open (doesn&apos;t have to be active).</value>
+    <value>Provides an ON/OFF value based on whether the window is currently open (doesn't have to be active).</value>
   </data>
   <data name="SensorsManager_NetworkSensorsDescription" xml:space="preserve">
 	  <value>Provides card info, configuration, transfer- &amp; package statistics and addresses (ip, mac, dhcp, dns) of the selected network card(s).
@@ -2592,7 +2593,7 @@ Do you still want to use the current values?</value>
     <value>ApplicationStarted</value>
   </data>
   <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
-    <value>You can use the satellite service to run sensors and commands without having to be logged in. Not all types are available, for instance the &apos;LaunchUrl&apos; command can only be added as a regular command.</value>
+    <value>You can use the satellite service to run sensors and commands without having to be logged in. Not all types are available, for instance the 'LaunchUrl' command can only be added as a regular command.</value>
   </data>
   <data name="SensorsConfig_ClmValue" xml:space="preserve">
     <value>Last Known Value</value>
@@ -2708,7 +2709,7 @@ Note: this is not required for the new integration to function. Only enable and 
     <value>&amp;Enable Media Player Functionality</value>
   </data>
   <data name="ConfigMediaPlayer_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent can act as a media player for Home Assistant, so you&apos;ll be able to see and control any media that&apos;s playing, and send text-to-speech. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
+    <value>HASS.Agent can act as a media player for Home Assistant, so you'll be able to see and control any media that's playing, and send text-to-speech. If you have MQTT enabled, your device will automatically get added. Otherwise, manually configure the integration to use the local API.</value>
   </data>
   <data name="ConfigMediaPlayer_LblInfo2" xml:space="preserve">
 	  <value>If something is not working, make sure you try the following steps:
@@ -2762,10 +2763,10 @@ Note: this is not required for the new integration to function. Only enable and 
     <value>Tray Icon</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
-    <value>Your input language &apos;{0}&apos; is known to collide with the default CTRL-ALT-Q hotkey. Please set your own.</value>
+    <value>Your input language '{0}' is known to collide with the default CTRL-ALT-Q hotkey. Please set your own.</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
-    <value>Your input language &apos;{0}&apos; is unknown, and might collide with the default CTRL-ALT-Q hotkey. Please check to be sure. If it does, consider opening a ticket on GitHub so it can be added to the list.</value>
+    <value>Your input language '{0}' is unknown, and might collide with the default CTRL-ALT-Q hotkey. Please check to be sure. If it does, consider opening a ticket on GitHub so it can be added to the list.</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
     <value>No keys found</value>
@@ -2777,7 +2778,7 @@ Note: this is not required for the new integration to function. Only enable and 
     <value>Error while parsing keys, please check the logs for more information.</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
-    <value>The number of open brackets (&apos;[&apos;) does not correspond to the number of closed brackets. (&apos;]&apos;)! ({0} to {1})</value>
+    <value>The number of open brackets ('[') does not correspond to the number of closed brackets. (']')! ({0} to {1})</value>
   </data>
   <data name="Help_LblDocumentation" xml:space="preserve">
     <value>Documentation</value>
@@ -2810,7 +2811,7 @@ information.</value>
 -Restart Home Assistant</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo3" xml:space="preserve">
-    <value>The same goes for the media player, this integration allows you to control your device as a media_player entity, see what&apos;s playing and send text-to-speech.</value>
+    <value>The same goes for the media player, this integration allows you to control your device as a media_player entity, see what's playing and send text-to-speech.</value>
   </data>
   <data name="OnboardingIntegrations_LblMediaPlayerIntegration" xml:space="preserve">
     <value>HASS.Agent-MediaPlayer GitHub Page</value>
@@ -2833,7 +2834,7 @@ information.</value>
 Do you want to enable it?</value>
   </data>
   <data name="OnboardingLocalApi_LblInfo2" xml:space="preserve">
-    <value>You can choose what modules you want to enable. They require HA integrations, but don&apos;t worry, the next page will give you more info on how to set them up.</value>
+    <value>You can choose what modules you want to enable. They require HA integrations, but don't worry, the next page will give you more info on how to set them up.</value>
   </data>
   <data name="OnboardingLocalApi_LblTip1" xml:space="preserve">
     <value>Note: 5115 is the default port, only change it if you changed it in Home Assistant.</value>
@@ -2864,10 +2865,10 @@ Do you want to use that version?</value>
     <value>&amp;Always show centered in screen</value>
   </data>
   <data name="WebViewCommandConfig_CbShowTitleBar" xml:space="preserve">
-    <value>Show the window&apos;s &amp;title bar</value>
+    <value>Show the window's &amp;title bar</value>
   </data>
   <data name="WebViewCommandConfig_CbTopMost" xml:space="preserve">
-    <value>Set window as &apos;Always on &amp;Top&apos;</value>
+    <value>Set window as 'Always on &amp;Top'</value>
   </data>
   <data name="WebViewCommandConfig_LblInfo1" xml:space="preserve">
     <value>Drag and resize this window to set the size and location of your webview command.</value>
@@ -2902,7 +2903,7 @@ Please ensure the keycode field is in focus and press the key you want simulated
     <value>Enable State Notifications</value>
   </data>
   <data name="ConfigGeneral_LblInfo5" xml:space="preserve">
-    <value>HASS.Agent will sanitize your device name to make sure HA will accept it, you can overrule this rule below if you&apos;re sure that your name will be accepted as-is.</value>
+    <value>HASS.Agent will sanitize your device name to make sure HA will accept it, you can overrule this rule below if you're sure that your name will be accepted as-is.</value>
   </data>
   <data name="ConfigGeneral_LblInfo6" xml:space="preserve">
     <value>HASS.Agent sends notifications when the state of a module changes, you can adjust whether or not you want to receive these notifications below.</value>
@@ -2974,7 +2975,7 @@ Note: You disabled sanitation, so make sure your device name is accepted by Home
     <value>Puts all monitors in sleep (low power) mode.</value>
   </data>
   <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
-    <value>Tries to wake up all monitors by simulating a &apos;arrow up&apos; keypress.</value>
+    <value>Tries to wake up all monitors by simulating a 'arrow up' keypress.</value>
   </data>
   <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
     <value>Sets the volume of the current default audiodevice to the specified level.</value>
@@ -3033,7 +3034,7 @@ Are you sure you want to use this URI anyway?</value>
 Please start the service first in order to configure it.</value>
   </data>
   <data name="ConfigService_LblInfo5" xml:space="preserve">
-    <value>If you want to manage the service (add commands and sensor, change settings) you can do so here, or by using the &apos;satellite service&apos; button on the main window.</value>
+    <value>If you want to manage the service (add commands and sensor, change settings) you can do so here, or by using the 'satellite service' button on the main window.</value>
   </data>
   <data name="ConfigTrayIcon_CbWebViewShowMenuOnLeftClick" xml:space="preserve">
     <value>Show default menu on mouse left-click</value>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.es.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.es.resx
@@ -137,7 +137,7 @@
   </data>
   <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
     <value>Puede configurar HASS.Agent para usar un ejecutor específico, como perl o python.
-Use el comando &apos;ejecutor personalizado&apos; para iniciar este ejecutor.</value>
+Use el comando 'ejecutor personalizado' para iniciar este ejecutor.</value>
   </data>
   <data name="ConfigExternalTools_LblCustomExecutorName" xml:space="preserve">
     <value>nombre del ejecutor personalizado</value>
@@ -191,7 +191,7 @@ la API de Home Assistant.
 
 Por favor, proporcione un token de acceso de larga duración, y la dirección de su instancia de Home Assistant.
 
-Puedes obtener un token a través de tu página de perfil. Desplácese hasta la parte inferior y haga clic en &apos;CREAR TOKEN&apos;.</value>
+Puedes obtener un token a través de tu página de perfil. Desplácese hasta la parte inferior y haga clic en 'CREAR TOKEN'.</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
     <value>&amp;api token</value>
@@ -229,7 +229,7 @@ De esta manera, hagas lo que hagas en tu máquina, siempre puedes interactuar co
     <value>Algunos elementos, como las imágenes que se muestran en las notificaciones, deben almacenarse temporalmente de forma local. Puede
 configurar la cantidad de días que deben conservarse antes de que HASS.Agent los elimine.
 
-Introduzca &apos;0&apos; para mantenerlas permanentemente.</value>
+Introduzca '0' para mantenerlas permanentemente.</value>
   </data>
   <data name="ConfigLogging_LblInfo1" xml:space="preserve">
     <value>El registro extendido proporciona un registro más detallado, en caso de que el registro predeterminado no sea
@@ -324,7 +324,7 @@ Nota: estos ajustes (excepto el id de cliente) se aplicarán también al servici
   </data>
   <data name="ConfigService_LblInfo1" xml:space="preserve">
     <value>El servicio satelital le permite ejecutar sensores y comandos incluso cuando ningún usuario ha iniciado sesión.
-Use el botón &apos;servicio satelital&apos; en la ventana principal para administrarlo.</value>
+Use el botón 'servicio satelital' en la ventana principal para administrarlo.</value>
   </data>
   <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
     <value>estado del servicio:</value>
@@ -393,7 +393,7 @@ Recibirá una notificación (una vez por actualización) que le informará que h
   <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
     <value>Parece que esta es la primera vez que inicia HASS.Agent.
 
-Si quieres, podemos pasar por la configuración. Si no, simplemente haga clic en &apos;cerrar&apos;.</value>
+Si quieres, podemos pasar por la configuración. Si no, simplemente haga clic en 'cerrar'.</value>
   </data>
   <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
     <value>El nombre del dispositivo se usa para identificar su máquina en HA.
@@ -455,7 +455,7 @@ información.</value>
 la API de Home Assistant.
 
 Por favor, proporcione un token de acceso de larga duración, y la dirección de su instancia de Home Assistant.
-Puedes obtener un token a través de su página de perfil. Desplácese hasta la parte inferior y haga clic en &apos;CREAR TOKEN&apos;.</value>
+Puedes obtener un token a través de su página de perfil. Desplácese hasta la parte inferior y haga clic en 'CREAR TOKEN'.</value>
   </data>
   <data name="OnboardingApi_BtnTest" xml:space="preserve">
     <value>&amp;conexión de prueba</value>
@@ -809,7 +809,7 @@ probablemente puedas usar la dirección preestablecida.</value>
     <value>descripción</value>
   </data>
   <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
-    <value>&amp;ejecutar como &apos;baja integridad&apos;</value>
+    <value>&amp;ejecutar como 'baja integridad'</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
     <value>¿Qué es esto?</value>
@@ -1010,7 +1010,7 @@ probablemente puedas usar la dirección preestablecida.</value>
 los componentes usados para sus licencias individuales:</value>
   </data>
   <data name="About_LblInfo4" xml:space="preserve">
-    <value>Un gran &apos;gracias&apos; a los desarrolladores de estos proyectos, que tuvieron la amabilidad de compartir
+    <value>Un gran 'gracias' a los desarrolladores de estos proyectos, que tuvieron la amabilidad de compartir
 su arduo trabajo con el resto de nosotros, meros mortales.</value>
   </data>
   <data name="About_LblInfo5" xml:space="preserve">
@@ -1232,31 +1232,32 @@ reportar errores o simplemente hablar de lo que sea.</value>
   <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
     <value>Ejecute un comando personalizado.
 
-Estos comandos se ejecutan sin elevación especial. Para ejecutar elevado, cree una tarea programada y use &apos;schtasks /Run /TN &quot;TaskName&quot;&apos; como comando para ejecutar su tarea.
+Estos comandos se ejecutan sin elevación especial. Para ejecutar elevado, cree una tarea programada y use 'schtasks /Run /TN "TaskName"' como comando para ejecutar su tarea.
 
-O habilite &apos;ejecutar como baja integridad&apos; para una ejecución aún más estricta.</value>
+O habilite 'ejecutar como baja integridad' para una ejecución aún más estricta.</value>
   </data>
   <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
     <value>Ejecuta el comando a través del ejecutor personalizado configurado (en Configuración -&gt; Herramientas externas).
 
-Su comando se proporciona como un argumento &apos;tal cual&apos;, por lo que debe proporcionar sus propias comillas, etc., si es necesario.</value>
+Su comando se proporciona como un argumento 'tal cual', por lo que debe proporcionar sus propias comillas, etc., si es necesario.</value>
   </data>
   <data name="CommandsManager_HibernateCommandDescription" xml:space="preserve">
     <value>Pone la máquina en hibernación.</value>
   </data>
   <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
-    <value>Simula la pulsación de una sola tecla.
+    <value>Simula una sola pulsación de tecla.
 
-Haga clic en el cuadro de texto &quot;código de teclas&quot; y pulse la tecla que desea simular. El código de la tecla correspondiente se introducirá por usted.
+Haga clic en el cuadro de texto 'keycode' y presione la tecla que desea simular. El código clave correspondiente se ingresará por usted.
+Para la tecla TAB, utilice LCTRL+TAB.
 
 Si necesita más teclas y/o modificadores como CTRL, use el comando MultipleKeys.</value>
   </data>
   <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
     <value>Lanza la URL proporcionada, por defecto en su navegador predeterminado.
 
-Para usar &apos;incógnito&apos;, proporcione un navegador específico en Configuración -&gt; Herramientas externas.
+Para usar 'incógnito', proporcione un navegador específico en Configuración -&gt; Herramientas externas.
 
-Si sólo quiere una ventana con una URL específica (no un navegador completo), use un comando &apos;WebView&apos;.</value>
+Si sólo quiere una ventana con una URL específica (no un navegador completo), use un comando 'WebView'.</value>
   </data>
   <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
     <value>Bloquea la sesión actual.</value>
@@ -1265,22 +1266,22 @@ Si sólo quiere una ventana con una URL específica (no un navegador completo), 
     <value>Cierra la sesión actual.</value>
   </data>
   <data name="CommandsManager_MediaMuteCommandDescription" xml:space="preserve">
-    <value>Simula la tecla &apos;silencio&apos;.</value>
+    <value>Simula la tecla 'silencio'.</value>
   </data>
   <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
-    <value>Simula la tecla &apos;media next&apos;.</value>
+    <value>Simula la tecla 'media next'.</value>
   </data>
   <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
-    <value>Simula la tecla &apos;pausa de reproducción multimedia&apos;.</value>
+    <value>Simula la tecla 'pausa de reproducción multimedia'.</value>
   </data>
   <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
-    <value>Simula la tecla &apos;media anterior&apos;.</value>
+    <value>Simula la tecla 'media anterior'.</value>
   </data>
   <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
-    <value>Simula la tecla de &apos;bajar volumen&apos;.</value>
+    <value>Simula la tecla de 'bajar volumen'.</value>
   </data>
   <data name="CommandsManager_MediaVolumeUpCommandDescription" xml:space="preserve">
-    <value>Simula la tecla &apos;subir volumen&apos;.</value>
+    <value>Simula la tecla 'subir volumen'.</value>
   </data>
   <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
     <value>Simula la pulsación de varias teclas.
@@ -1314,12 +1315,12 @@ Esto se ejecutará sin elevación especial.</value>
   <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
     <value>Reinicia la máquina después de un minuto.
 
-Consejo: ¿activado accidentalmente? Ejecute &apos;shutdown /a&apos; para cancelar.</value>
+Consejo: ¿activado accidentalmente? Ejecute 'shutdown /a' para cancelar.</value>
   </data>
   <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
     <value>Apaga la máquina después de un minuto.
 
-Consejo: ¿activado accidentalmente? Ejecute &apos;shutdown /a&apos; para cancelar.</value>
+Consejo: ¿activado accidentalmente? Ejecute 'shutdown /a' para cancelar.</value>
   </data>
   <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
     <value>Pone la máquina a dormir.
@@ -1408,7 +1409,7 @@ Recuerde cambiar también el puerto de su regla de firewall.</value>
 Consulte los registros de HASS.Agent (no el servicio) para obtener más información.</value>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
-    <value>El servicio está configurado como &apos;deshabilitado&apos;, por lo que no se puede iniciar.
+    <value>El servicio está configurado como 'deshabilitado', por lo que no se puede iniciar.
 
 Habilite primero el servicio y luego inténtelo de nuevo.</value>
   </data>
@@ -1583,7 +1584,7 @@ Deje vacío para permitir que todos se conecten.</value>
   <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
     <value>Este es el nombre con el que el servicio satelital se registra en Home Assistant.
 
-De manera predeterminada, es el nombre de su PC más &apos;-satélite&apos;.</value>
+De manera predeterminada, es el nombre de su PC más '-satélite'.</value>
   </data>
   <data name="ServiceGeneral_LblDisconGraceInfo_MessageBox1" xml:space="preserve">
     <value>La cantidad de tiempo que esperará el servicio satelital antes de informar una conexión perdida al intermediario MQTT.</value>
@@ -1665,12 +1666,12 @@ Por favor, consulte los registros para obtener más información.</value>
     <value>Ya hay un comando con ese nombre. Estás seguro de que quieres continuar?</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox4" xml:space="preserve">
-    <value>Si no ingresa un comando, solo puede usar esta entidad con un valor de &apos;acción&apos; a través de Home Assistant. Ejecutarlo como está no hará nada.
+    <value>Si no ingresa un comando, solo puede usar esta entidad con un valor de 'acción' a través de Home Assistant. Ejecutarlo como está no hará nada.
 
 ¿Estás seguro de que quieres esto?</value>
   </data>
   <data name="CommandsMod_MessageBox_Action" xml:space="preserve">
-    <value>Si no ingresa un comando o secuencia de comandos, solo puede usar esta entidad con un valor de &apos;acción&apos; a través de Home Assistant. Ejecutarlo como está no hará nada.
+    <value>Si no ingresa un comando o secuencia de comandos, solo puede usar esta entidad con un valor de 'acción' a través de Home Assistant. Ejecutarlo como está no hará nada.
 
 ¿Estás seguro de que quieres esto?</value>
   </data>
@@ -1681,7 +1682,7 @@ Por favor, consulte los registros para obtener más información.</value>
     <value>No se han podido comprobar las claves: {0}</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
-    <value>Si no ingresa una URL, solo puede usar esta entidad con un valor de &apos;acción&apos; a través de Home Assistant. Ejecutarlo como está no hará nada.
+    <value>Si no ingresa una URL, solo puede usar esta entidad con un valor de 'acción' a través de Home Assistant. Ejecutarlo como está no hará nada.
 
 ¿Estás seguro de que quieres esto?</value>
   </data>
@@ -1726,10 +1727,10 @@ configure un ejecutor o su comando no se ejecutará</value>
     <value>Eso significa que solo podrá guardar y modificar archivos en ciertas ubicaciones,</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
-    <value>como la carpeta &apos;%USERPROFILE%\AppData\LocalLow&apos; o</value>
+    <value>como la carpeta '%USERPROFILE%\AppData\LocalLow' o</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
-    <value>la clave de registro &apos;HKEY_CURRENT_USER\Software\AppDataLow&apos;.</value>
+    <value>la clave de registro 'HKEY_CURRENT_USER\Software\AppDataLow'.</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
     <value>Debe probar su comando para asegurarse de que no esté influenciado por esto.</value>
@@ -1846,7 +1847,7 @@ Todos sus sensores y comandos serán ahora despublicados, y HASS.Agent se reinic
 
 No se preocupe, mantendrán sus nombres actuales, por lo que sus automatizaciones o scripts seguirán funcionando.
 
-Nota: el nombre será &apos;saneado&apos;, lo que significa que todo, excepto las letras, los dígitos y los espacios en blanco, será reemplazado por un guión bajo. Esto es requerido por HA.</value>
+Nota: el nombre será 'saneado', lo que significa que todo, excepto las letras, los dígitos y los espacios en blanco, será reemplazado por un guión bajo. Esto es requerido por HA.</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox2" xml:space="preserve">
     <value>Ha cambiado el puerto de la API local. Este nuevo puerto necesita ser reservado.
@@ -1876,7 +1877,7 @@ Reinicie manualmente.</value>
   <data name="Main_Load_MessageBox1" xml:space="preserve">
     <value>Algo ha ido mal al cargar la configuración.
 
-Compruebe el archivo appsettings.json en la subcarpeta &quot;config&quot; o elimínelo para empezar de cero.</value>
+Compruebe el archivo appsettings.json en la subcarpeta "config" o elimínelo para empezar de cero.</value>
   </data>
   <data name="Main_Load_MessageBox2" xml:space="preserve">
     <value>Se ha producido un error al lanzar HASS.Agent.
@@ -2029,7 +2030,7 @@ Asegúrese de que no se esté ejecutando ninguna otra instancia de HASS.Agent y 
   <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
     <value>Brinda información sobre varios aspectos del audio de su dispositivo:
 
-Nivel de volumen máximo actual (se puede usar como un simple valor de &quot;se está reproduciendo algo&quot;).
+Nivel de volumen máximo actual (se puede usar como un simple valor de "se está reproduciendo algo").
 
 Dispositivo de audio predeterminado: nombre, estado y volumen.
 
@@ -2067,7 +2068,7 @@ Actualmente toma el volumen de su dispositivo predeterminado.</value>
   <data name="SensorsManager_LastBootSensorDescription" xml:space="preserve">
     <value>Proporciona un valor de fecha y hora que contiene el último momento en que el sistema (re)arrancó.
 
-Importante: la opción FastBoot de Windows puede descartar este valor, porque es una forma de hibernación. Puede deshabilitarlo a través de Opciones de energía -&gt; &apos;Elegir lo que hacen los botones de encendido&apos; -&gt; desmarque &apos;Activar inicio rápido&apos;. No hace mucha diferencia para las máquinas modernas con SSD, pero la desactivación asegura que obtenga un estado limpio después de reiniciar.</value>
+Importante: la opción FastBoot de Windows puede descartar este valor, porque es una forma de hibernación. Puede deshabilitarlo a través de Opciones de energía -&gt; 'Elegir lo que hacen los botones de encendido' -&gt; desmarque 'Activar inicio rápido'. No hace mucha diferencia para las máquinas modernas con SSD, pero la desactivación asegura que obtenga un estado limpio después de reiniciar.</value>
   </data>
   <data name="SensorsManager_LastSystemStateChangeSensorDescription" xml:space="preserve">
     <value>Proporciona el último cambio de estado del sistema:
@@ -2107,7 +2108,7 @@ Categoría: Procesador
 Contador: % de tiempo de procesador
 Instancia: _Total
 
-Puede explorar los contadores a través de la herramienta &apos;perfmon.exe&apos; de Windows.</value>
+Puede explorar los contadores a través de la herramienta 'perfmon.exe' de Windows.</value>
   </data>
   <data name="SensorsManager_ProcessActiveSensorDescription" xml:space="preserve">
     <value>Proporciona el número de instancias activas del proceso.</value>
@@ -2116,7 +2117,7 @@ Puede explorar los contadores a través de la herramienta &apos;perfmon.exe&apos
   <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
     <value>Devuelve el estado del servicio proporcionado: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending o Paused.
 
-Asegúrese de proporcionar el &apos;Nombre del servicio&apos;, no el &apos;Nombre para mostrar&apos;.</value>
+Asegúrese de proporcionar el 'Nombre del servicio', no el 'Nombre para mostrar'.</value>
   </data>
   <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
     <value>Proporciona el estado actual de la sesión:
@@ -2594,7 +2595,7 @@ Sugerencia: asegúrese de no haber cambiado el alcance y los campos de consulta.
     <value>Aplicación iniciada</value>
   </data>
   <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
-    <value>Puede usar el servicio satelital para ejecutar sensores y comandos sin tener que iniciar sesión. No todos los tipos están disponibles, por ejemplo, el comando &apos;LaunchUrl&apos; solo se puede agregar como un comando normal.</value>
+    <value>Puede usar el servicio satelital para ejecutar sensores y comandos sin tener que iniciar sesión. No todos los tipos están disponibles, por ejemplo, el comando 'LaunchUrl' solo se puede agregar como un comando normal.</value>
   </data>
   <data name="SensorsConfig_ClmValue" xml:space="preserve">
     <value>último valor conocido</value>
@@ -2613,7 +2614,7 @@ Asegúrese de que no se esté ejecutando ninguna otra instancia de HASS.Agent y 
   <data name="CommandsManager_WebViewCommandDescription" xml:space="preserve">
     <value>Muestra una ventana con la URL proporcionada.
 
-Esto difiere del comando &apos;LaunchUrl&apos; en que no carga un navegador completo, solo la URL provista en su propia ventana.
+Esto difiere del comando 'LaunchUrl' en que no carga un navegador completo, solo la URL provista en su propia ventana.
 
 Puede usar esto para, por ejemplo, mostrar rápidamente el panel de Home Assistant.
 
@@ -2627,10 +2628,10 @@ De forma predeterminada, almacena cookies de forma indefinida, por lo que solo t
 
 Si la aplicación está minimizada, se restaurará.
 
-Ejemplo: si desea enviar VLC al primer plano, use &apos;vlc&apos;.</value>
+Ejemplo: si desea enviar VLC al primer plano, use 'vlc'.</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
-    <value>Si no configura el comando, solo puede usar esta entidad con un valor de &apos;acción&apos; a través de Home Assistant y se mostrará con la configuración predeterminada. Ejecutarlo como está no hará nada.
+    <value>Si no configura el comando, solo puede usar esta entidad con un valor de 'acción' a través de Home Assistant y se mostrará con la configuración predeterminada. Ejecutarlo como está no hará nada.
 
 ¿Estás seguro de que quieres esto? </value>
   </data>
@@ -2764,10 +2765,10 @@ Nota: esto no es necesario para que la nueva integración funcione. Sólo actív
     <value>Icono de bandeja</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
-    <value>Se sabe que su idioma de entrada &apos;{0}&apos; colisiona con la tecla de acceso directo predeterminada CTRL-ALT-Q. Establezca el suyo propio.</value>
+    <value>Se sabe que su idioma de entrada '{0}' colisiona con la tecla de acceso directo predeterminada CTRL-ALT-Q. Establezca el suyo propio.</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
-    <value>Su idioma de entrada &apos;{0}&apos; es desconocido y podría colisionar con la tecla de acceso directo predeterminada CTRL-ALT-Q. Por favor verifique para estar seguro. Si es así, considere abrir un ticket en GitHub para que pueda agregarse a la lista.</value>
+    <value>Su idioma de entrada '{0}' es desconocido y podría colisionar con la tecla de acceso directo predeterminada CTRL-ALT-Q. Por favor verifique para estar seguro. Si es así, considere abrir un ticket en GitHub para que pueda agregarse a la lista.</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
     <value>no se encontraron llaves</value>
@@ -2779,7 +2780,7 @@ Nota: esto no es necesario para que la nueva integración funcione. Sólo actív
     <value>error al analizar las claves, verifique el registro para obtener más información</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
-    <value>el número de corchetes &apos;[&apos; no corresponde a los &apos;]&apos; ({0} a {1})</value>
+    <value>el número de corchetes '[' no corresponde a los ']' ({0} a {1})</value>
   </data>
   <data name="Help_LblDocumentation" xml:space="preserve">
     <value>Documentación</value>
@@ -2881,7 +2882,7 @@ El nombre final es: {0}
     <value>Talla</value>
   </data>
   <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
-    <value>consejo: presione &apos;esc&apos; para cerrar una vista web</value>
+    <value>consejo: presione 'esc' para cerrar una vista web</value>
   </data>
   <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
     <value>&amp;URL</value>
@@ -2988,7 +2989,7 @@ Nota: deshabilitó el saneamiento, así que asegúrese de que Home Assistant ace
     <value>Comando</value>
   </data>
   <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
-    <value>Si no introduce un valor de volumen, sólo podrá usar esta entidad con un valor de &quot;acción&quot; a través del Asistente de Inicio. Ejecutarlo tal cual no hará nada.
+    <value>Si no introduce un valor de volumen, sólo podrá usar esta entidad con un valor de "acción" a través del Asistente de Inicio. Ejecutarlo tal cual no hará nada.
 
 ¿Está seguro de que quiere esto?</value>
   </data>
@@ -3006,7 +3007,7 @@ Debería contener tres secciones (separadas por dos puntos).
 ¿Está seguro de que quiere usarlo así?</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox6" xml:space="preserve">
-    <value>Su URI no parece correcta. Debería ser algo como &apos;http://homeassistant.local:8123&apos; o &apos;http://192.168.0.1:8123&apos;.
+    <value>Su URI no parece correcta. Debería ser algo como 'http://homeassistant.local:8123' o 'http://192.168.0.1:8123'.
 
 ¿Está seguro de que quiere usarlo así?</value>
   </data>
@@ -3034,7 +3035,7 @@ Debería contener tres secciones (separadas por dos puntos).
 Asegúrese primero de tenerlo en funcionamiento.</value>
   </data>
   <data name="ConfigService_LblInfo5" xml:space="preserve">
-    <value>Si quiere gestionar el servicio (añadir comandos y sensores, cambiar la configuración) puede hacerlo aquí, o usando el botón &quot;servicio de satélite&quot; en la ventana principal.</value>
+    <value>Si quiere gestionar el servicio (añadir comandos y sensores, cambiar la configuración) puede hacerlo aquí, o usando el botón "servicio de satélite" en la ventana principal.</value>
   </data>
   <data name="ConfigTrayIcon_CbWebViewShowMenuOnLeftClick" xml:space="preserve">
     <value>mostrar el menú predeterminado al hacer clic con el botón izquierdo del ratón</value>
@@ -3046,12 +3047,12 @@ Debería contener tres secciones (separadas por dos puntos).
 ¿Está seguro de que quiere usarlo así?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
-    <value>Su URI del Asistente de Inicio no se ve bien. Debería ser algo como &apos;http://homeassistant.local:8123&apos; o &apos;https://192.168.0.1:8123&apos;.
+    <value>Su URI del Asistente de Inicio no se ve bien. Debería ser algo como 'http://homeassistant.local:8123' o 'https://192.168.0.1:8123'.
 
 ¿Está seguro de que quiere usarlo así?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
-    <value>Su URI del broker MQTT no parece correcta. Debería ser algo como &apos;homeassistant.local&apos; o &apos;192.168.0.1&apos;.
+    <value>Su URI del broker MQTT no parece correcta. Debería ser algo como 'homeassistant.local' o '192.168.0.1'.
 
 ¿Está seguro de que quiere usarlo así?</value>
   </data>
@@ -3084,7 +3085,7 @@ Debería contener tres secciones (separadas por dos puntos).
 ¿Está seguro de que quiere usarlo así?</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox6" xml:space="preserve">
-    <value>Su URI no parece correcto. Debería ser algo como &apos;http://homeassistant.local:8123&apos; o &apos;http://192.168.0.1:8123&apos;.
+    <value>Su URI no parece correcto. Debería ser algo como 'http://homeassistant.local:8123' o 'http://192.168.0.1:8123'.
 
 ¿Está seguro de que quiere usarlo así?</value>
   </data>
@@ -3123,7 +3124,7 @@ Sólo muestra los dispositivos que fueron vistos desde el último informe, es de
 
 Asegúrese de que los servicios de localización de Windows están activados.
 
-Dependiendo de su versión de Windows, esto se puede encontrar en el nuevo panel de control -&gt; &apos;privacidad y seguridad&apos; -&gt; &apos;ubicación&apos;.</value>
+Dependiendo de su versión de Windows, esto se puede encontrar en el nuevo panel de control -&gt; 'privacidad y seguridad' -&gt; 'ubicación'.</value>
   </data>
   <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
     <value>Proporciona el nombre del proceso que está usando actualmente el micrófono.

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.fr.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.fr.resx
@@ -124,24 +124,24 @@
     <value>Nom du navigateur</value>
   </data>
   <data name="ConfigExternalTools_LblInfo2" xml:space="preserve">
-    <value>Par défaut, HASS.Agent lancera les URL à l&apos;aide de votre navigateur par défaut. Si vous le souhaitez, vous pouvez également configurer un navigateur spécifique. De plus, vous pouvez configurer les arguments utilisés pour lancer
+    <value>Par défaut, HASS.Agent lancera les URL à l'aide de votre navigateur par défaut. Si vous le souhaitez, vous pouvez également configurer un navigateur spécifique. De plus, vous pouvez configurer les arguments utilisés pour lancer
 en mode privé.</value>
   </data>
   <data name="ConfigExternalTools_LblBrowserBinary" xml:space="preserve">
     <value>Exécutable du navigateur</value>
   </data>
   <data name="ConfigExternalTools_LblLaunchIncogArg" xml:space="preserve">
-    <value>Lancer avec l&apos;argument incognito</value>
+    <value>Lancer avec l'argument incognito</value>
   </data>
   <data name="ConfigExternalTools_LblCustomExecutorBinary" xml:space="preserve">
-    <value>Binaire de l&apos;exécuteur personnalisé</value>
+    <value>Binaire de l'exécuteur personnalisé</value>
   </data>
   <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
     <value>Vous pouvez configurer HASS.Agent pour utiliser un exécuteur spécifique, comme perl ou python.
-Utilisez la commande &apos;exécuteur personnalisé&apos; pour lancer cet exécuteur.</value>
+Utilisez la commande 'exécuteur personnalisé' pour lancer cet exécuteur.</value>
   </data>
   <data name="ConfigExternalTools_LblCustomExecutorName" xml:space="preserve">
-    <value>Nom de l&apos;exécuteur personnalisé</value>
+    <value>Nom de l'exécuteur personnalisé</value>
   </data>
   <data name="ConfigExternalTools_LblTip1" xml:space="preserve">
     <value>Conseil : double-cliquez pour parcourir</value>
@@ -150,7 +150,7 @@ Utilisez la commande &apos;exécuteur personnalisé&apos; pour lancer cet exécu
     <value>&amp;test</value>
   </data>
   <data name="ConfigGeneral_LblInfo4" xml:space="preserve">
-    <value>HASS.Agent attendra un moment avant de vous avertir des déconnexions de MQTT ou de l&apos;API HA.
+    <value>HASS.Agent attendra un moment avant de vous avertir des déconnexions de MQTT ou de l'API HA.
 Vous pouvez définir le nombre de secondes ici.</value>
   </data>
   <data name="ConfigGeneral_LblDisconGraceSeconds" xml:space="preserve">
@@ -160,18 +160,18 @@ Vous pouvez définir le nombre de secondes ici.</value>
     <value>Délai avant déconnection</value>
   </data>
   <data name="ConfigGeneral_LblInfo3" xml:space="preserve">
-    <value>Important : si vous modifiez cette valeur, HASS.Agent dépubliera tous vos capteurs et commandes et forcera un redémarrage de lui-même, afin qu&apos;ils puissent être republiés sous le nouveau nom de l&apos;appareil.
+    <value>Important : si vous modifiez cette valeur, HASS.Agent dépubliera tous vos capteurs et commandes et forcera un redémarrage de lui-même, afin qu'ils puissent être republiés sous le nouveau nom de l'appareil.
 Vos automatisations et scripts continueront de fonctionner.</value>
   </data>
   <data name="ConfigGeneral_LblInfo2" xml:space="preserve">
-    <value>Le nom de l&apos;appareil est utilisé pour identifier votre machine sur HA.
+    <value>Le nom de l'appareil est utilisé pour identifier votre machine sur HA.
 Il est également utilisé comme préfixe pour vos noms de commande/capteur (peut être modifié par entité).</value>
   </data>
   <data name="ConfigGeneral_LblInfo1" xml:space="preserve">
     <value>Cette page contient les paramètres généraux. Plus de paramètres dans les onglets sur la gauche.</value>
   </data>
   <data name="ConfigGeneral_LblDeviceName" xml:space="preserve">
-    <value>Nom de l&apos;appareil</value>
+    <value>Nom de l'appareil</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblTip1" xml:space="preserve">
     <value>Conseil : double-cliquez sur ce champ pour parcourir</value>
@@ -186,11 +186,11 @@ Il est également utilisé comme préfixe pour vos noms de commande/capteur (peu
     <value>Tester la connexion</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblInfo1" xml:space="preserve">
-    <value>Pour connaître les entités que vous avez configurées et envoyer des actions rapides, HASS.Agent utilise l&apos;API de Home Assistant.
+    <value>Pour connaître les entités que vous avez configurées et envoyer des actions rapides, HASS.Agent utilise l'API de Home Assistant.
 
-Veuillez fournir un jeton d&apos;accès de longue durée et l&apos;adresse de votre instance Home Assistant.
+Veuillez fournir un jeton d'accès de longue durée et l'adresse de votre instance Home Assistant.
 
-Vous pouvez obtenir un jeton via votre page de profil. Faites défiler vers le bas et cliquez sur &quot;CRÉER UN JETON&quot;.</value>
+Vous pouvez obtenir un jeton via votre page de profil. Faites défiler vers le bas et cliquez sur "CRÉER UN JETON".</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
@@ -203,7 +203,7 @@ Vous pouvez obtenir un jeton via votre page de profil. Faites défiler vers le b
     <value>Effacer</value>
   </data>
   <data name="ConfigHotKey_LblInfo1" xml:space="preserve">
-    <value>Un moyen simple d&apos;afficher vos actions rapides consiste à utiliser un raccourci clavier global.
+    <value>Un moyen simple d'afficher vos actions rapides consiste à utiliser un raccourci clavier global.
 
 De cette façon, quoi que vous fassiez sur votre machine, vous pouvez toujours interagir avec Home Assistant.</value>
   </data>
@@ -214,24 +214,24 @@ De cette façon, quoi que vous fassiez sur votre machine, vous pouvez toujours i
     <value>Combinaison du raccourcis clavier</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearImageCache" xml:space="preserve">
-    <value>Effacer le cache d&apos;image</value>
+    <value>Effacer le cache d'image</value>
   </data>
   <data name="ConfigLocalStorage_BtnOpenImageCache" xml:space="preserve">
     <value>Ouvrir le dossier</value>
   </data>
   <data name="ConfigLocalStorage_LblCacheLocations" xml:space="preserve">
-    <value>Emplacement du cache d&apos;images</value>
+    <value>Emplacement du cache d'images</value>
   </data>
   <data name="ConfigLocalStorage_LblCacheDays" xml:space="preserve">
     <value>Jours</value>
   </data>
   <data name="ConfigLocalStorage_LblInfo1" xml:space="preserve">
     <value>Les images affichées dans les notifications doivent être temporairement stockées localement. Vous pouvez configurer le nombre de
-jours de conservation avant que HASS.Agent ne les supprimes. Entrez &apos;0&apos; pour les conserver en permanence.</value>
+jours de conservation avant que HASS.Agent ne les supprimes. Entrez '0' pour les conserver en permanence.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigLogging_LblInfo1" xml:space="preserve">
-    <value>Les logs étendus fournit un log plus détaillée et plus approfondie, au cas où celle par défaut ne serait pas suffisante. Veuillez noter que l&apos;activation de cette option peut entraîner une augmentation de la taille des fichiers journaux et doit être utilisé seulement lorsque vous soupçonnez que quelque chose ne va pas avec HASS.Agent lui-même ou lorsque demandé par le développeurs.</value>
+    <value>Les logs étendus fournit un log plus détaillée et plus approfondie, au cas où celle par défaut ne serait pas suffisante. Veuillez noter que l'activation de cette option peut entraîner une augmentation de la taille des fichiers journaux et doit être utilisé seulement lorsque vous soupçonnez que quelque chose ne va pas avec HASS.Agent lui-même ou lorsque demandé par le développeurs.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigLogging_CbExtendedLogging" xml:space="preserve">
@@ -259,11 +259,11 @@ jours de conservation avant que HASS.Agent ne les supprimes. Entrez &apos;0&apos
     <value>Effacer les paramètres</value>
   </data>
   <data name="ConfigMqtt_LblTip1" xml:space="preserve">
-    <value>(Laisser vide si vous n&apos;êtes pas sûr)</value>
+    <value>(Laisser vide si vous n'êtes pas sûr)</value>
   </data>
   <data name="ConfigMqtt_LblInfo1" xml:space="preserve">
-    <value>Les commandes et les capteurs sont envoyés via MQTT. Veuillez fournir les informations d&apos;identification de votre serveur. Si
-vous utilisez l&apos;addon HA, vous pouvez probablement utiliser l&apos;adresse prédéfinie.</value>
+    <value>Les commandes et les capteurs sont envoyés via MQTT. Veuillez fournir les informations d'identification de votre serveur. Si
+vous utilisez l'addon HA, vous pouvez probablement utiliser l'adresse prédéfinie.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigMqtt_LblDiscoPrefix" xml:space="preserve">
@@ -279,7 +279,7 @@ vous utilisez l&apos;addon HA, vous pouvez probablement utiliser l&apos;adresse 
     <value>Port</value>
   </data>
   <data name="ConfigMqtt_LblBrokerIp" xml:space="preserve">
-    <value>IP ou nom d&apos;hôte du broker</value>
+    <value>IP ou nom d'hôte du broker</value>
   </data>
   <data name="ConfigMqtt_LblTip2" xml:space="preserve">
     <value>(Laisser vide pour aléatoire)</value>
@@ -288,9 +288,9 @@ vous utilisez l&apos;addon HA, vous pouvez probablement utiliser l&apos;adresse 
     <value>ID du client</value>
   </data>
   <data name="ConfigNotifications_LblInfo2" xml:space="preserve">
-    <value>Si quelque chose ne fonctionne pas, assurez-vous d&apos;avoir suivi ces étapes :
+    <value>Si quelque chose ne fonctionne pas, assurez-vous d'avoir suivi ces étapes :
 
-- Installer l&apos;intégration HASS.Agent-Notifier
+- Installer l'intégration HASS.Agent-Notifier
 - Redémarrez Home Assistant
 - Configurer une entité de notification
 - Redémarrez Home Assistant</value>
@@ -320,7 +320,7 @@ vous utilisez l&apos;addon HA, vous pouvez probablement utiliser l&apos;adresse 
   </data>
   <data name="ConfigService_LblInfo1" xml:space="preserve">
     <value>Le Service Windows vous permet de lancer capteurs et commandes même sans utilisateur connecté.
-Utiliser le bouton &apos;Service Windows&apos; sur la fenêtre principale pour le gérer.</value>
+Utiliser le bouton 'Service Windows' sur la fenêtre principale pour le gérer.</value>
   </data>
   <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
     <value>Statuts du service</value>
@@ -346,11 +346,11 @@ Utiliser le bouton &apos;Service Windows&apos; sur la fenêtre principale pour l
   </data>
   <data name="ConfigService_LblInfo2" xml:space="preserve">
     <value>Si vous ne le configurez pas, il ne fera rien. Cependant, vous pouvez le désactiver quand même.
-L&apos;installateur laissera le service désactivé seul (si vous désinstallez le service, l&apos;installateur le réinstallera).</value>
+L'installateur laissera le service désactivé seul (si vous désinstallez le service, l'installateur le réinstallera).</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigService_LblInfo3" xml:space="preserve">
-    <value>Vous pouvez essayer de réinstaller le service s&apos;il ne fonctionne pas correctement.
+    <value>Vous pouvez essayer de réinstaller le service s'il ne fonctionne pas correctement.
 Vos paramètres et vos entités ne seront pas supprimées.</value>
   </data>
   <data name="ConfigService_BtnShowLogs" xml:space="preserve">
@@ -358,7 +358,7 @@ Vos paramètres et vos entités ne seront pas supprimées.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigService_LblInfo4" xml:space="preserve">
-    <value>Si le service continue d&apos;échouer après réinstallation, 
+    <value>Si le service continue d'échouer après réinstallation, 
 veuillez ouvrir un ticket et envoyer le contenu du dernier journal.</value>
   </data>
   <data name="ConfigStartup_LblInfo1" xml:space="preserve">
@@ -367,7 +367,7 @@ veuillez ouvrir un ticket et envoyer le contenu du dernier journal.</value>
 HASS.Agent étant basé sur un utilisateur, si vous voulez le lancer pour un autre utilisateur, installez et configurez HASS.Agent sur celui-ci.</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin" xml:space="preserve">
-    <value>Activer le démarrage à l&apos;ouverture de session</value>
+    <value>Activer le démarrage à l'ouverture de session</value>
   </data>
   <data name="ConfigStartup_LblStartOnLoginStatusInfo" xml:space="preserve">
     <value>Statut du démarrage auto :</value>
@@ -377,8 +377,8 @@ HASS.Agent étant basé sur un utilisateur, si vous voulez le lancer pour un aut
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigUpdates_LblInfo2" xml:space="preserve">
-    <value>Lorsqu&apos;il y a une mise à jour, HASS.Agent vous proposera l&apos;option d&apos;ouvrir la page de version. 
-Mais si vous voulez HASS.Agent peut également télécharger et lancer l&apos;installateur pour vous - encore moins de choses à faire !
+    <value>Lorsqu'il y a une mise à jour, HASS.Agent vous proposera l'option d'ouvrir la page de version. 
+Mais si vous voulez HASS.Agent peut également télécharger et lancer l'installateur pour vous - encore moins de choses à faire !
 Le fichier de certificat de téléchargement sera vérifié avant exécution.</value>
     <comment>Fuzzy</comment>
   </data>
@@ -389,24 +389,24 @@ Le fichier de certificat de téléchargement sera vérifié avant exécution.</v
   <data name="ConfigUpdates_LblInfo1" xml:space="preserve">
     <value>Si vous le souhaitez, HASS.Agent peut vérifier les mises à jour en arrière-plan.
 
-Vous recevrez une notification (une fois par mise à jour), vous informant qu&apos;une nouvelle version est prête à être installée.</value>
+Vous recevrez une notification (une fois par mise à jour), vous informant qu'une nouvelle version est prête à être installée.</value>
   </data>
   <data name="ConfigUpdates_CbUpdates" xml:space="preserve">
-    <value>Me notifier lors de la présence d&apos;une nouvelle version</value>
+    <value>Me notifier lors de la présence d'une nouvelle version</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
     <value>Il semble que ce soit la première fois que vous lanciez HASS.Agent.
 
 Pour vous aider lors de la première configuration, suivez les étapes de configuration ci-dessous
-ou bien, cliquez sur &apos;Fermer&apos;.</value>
+ou bien, cliquez sur 'Fermer'.</value>
   </data>
   <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
-    <value>Le nom de l&apos;appareil est utilisé pour identifier votre machine sur HA.
+    <value>Le nom de l'appareil est utilisé pour identifier votre machine sur HA.
 Il est également utilisé comme préfixe suggéré pour vos commandes et capteurs.</value>
   </data>
   <data name="OnboardingWelcome_LblDeviceName" xml:space="preserve">
-    <value>Nom de l&apos;appareil</value>
+    <value>Nom de l'appareil</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin" xml:space="preserve">
@@ -418,10 +418,10 @@ Il est également utilisé comme préfixe suggéré pour vos commandes et capteu
 Vous pouvez toujours supprimer (ou recréer) cette clé via la fenêtre de Paramètres.</value>
   </data>
   <data name="OnboardingStartup_LblCreateInfo" xml:space="preserve">
-    <value>Une seconde, détermination de l&apos;état actuel ..</value>
+    <value>Une seconde, détermination de l'état actuel ..</value>
   </data>
   <data name="OnboardingNotifications_LblTip1" xml:space="preserve">
-    <value>Remarque : 5115 est le port par défaut, ne le modifiez que si vous l&apos;avez modifié dans Home Assistant.</value>
+    <value>Remarque : 5115 est le port par défaut, ne le modifiez que si vous l'avez modifié dans Home Assistant.</value>
   </data>
   <data name="OnboardingNotifications_CbAcceptNotifications" xml:space="preserve">
     <value>Oui, accepter les notifications sur le port</value>
@@ -435,17 +435,17 @@ Voulez-vous activer cette fonction ?</value>
     <value>Page GitHub HASS.Agent-Notifier</value>
   </data>
   <data name="OnboardingIntegration_LblInfo2" xml:space="preserve">
-    <value>Assurez-vous d&apos;avoir suivi ces étapes :
+    <value>Assurez-vous d'avoir suivi ces étapes :
 
-- Installer l&apos;intégration HASS.Agent-Notifier
+- Installer l'intégration HASS.Agent-Notifier
 - Redémarrez Home Assistant
 - Configurer une entité de notification
 - Redémarrez Home Assistant</value>
   </data>
   <data name="OnboardingIntegration_LblInfo1" xml:space="preserve">
-    <value>Pour utiliser les notifications, vous devez installer et configurer l&apos;intégration HASS.Agent-notifier dans Home Assistant.
+    <value>Pour utiliser les notifications, vous devez installer et configurer l'intégration HASS.Agent-notifier dans Home Assistant.
 
-C&apos;est très facile avec HACS, mais vous pouvez également l&apos;installer manuellement. Visitez le lien ci-dessous pour plus
+C'est très facile avec HACS, mais vous pouvez également l'installer manuellement. Visitez le lien ci-dessous pour plus
 informations.</value>
   </data>
   <data name="OnboardingApi_LblApiToken" xml:space="preserve">
@@ -459,8 +459,8 @@ informations.</value>
     <value>Pour connaître les entités que vous avez configurées et envoyer des actions rapides, HASS.Agent utilise
 API de Home Assistant.
 
-Veuillez fournir un jeton d&apos;accès de longue durée et l&apos;adresse de votre instance Home Assistant.
-Vous pouvez obtenir un jeton via votre page de profil. Faites défiler vers le bas et cliquez sur &quot;CRÉER UN JETON&quot;.</value>
+Veuillez fournir un jeton d'accès de longue durée et l'adresse de votre instance Home Assistant.
+Vous pouvez obtenir un jeton via votre page de profil. Faites défiler vers le bas et cliquez sur "CRÉER UN JETON".</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="OnboardingApi_BtnTest" xml:space="preserve">
@@ -474,26 +474,26 @@ Vous pouvez obtenir un jeton via votre page de profil. Faites défiler vers le b
     <value>Mot de passe</value>
   </data>
   <data name="OnboardingMqtt_LblUsername" xml:space="preserve">
-    <value>Nom d&apos;utilisateur</value>
+    <value>Nom d'utilisateur</value>
   </data>
   <data name="OnboardingMqtt_LblPort" xml:space="preserve">
     <value>Port</value>
   </data>
   <data name="OnboardingMqtt_LblIpAdress" xml:space="preserve">
-    <value>IP ou nom d&apos;hôte</value>
+    <value>IP ou nom d'hôte</value>
   </data>
   <data name="OnboardingMqtt_LblInfo1" xml:space="preserve">
-    <value>Les commandes et les capteurs sont envoyés via MQTT. Veuillez fournir les informations d&apos;identification de votre serveur.
-Si vous utilisez l&apos;addon HA, vous pouvez probablement utiliser l&apos;adresse prédéfinie.
+    <value>Les commandes et les capteurs sont envoyés via MQTT. Veuillez fournir les informations d'identification de votre serveur.
+Si vous utilisez l'addon HA, vous pouvez probablement utiliser l'adresse prédéfinie.
 
-Laissez vide si vous n&apos;utilisez pas de commandes et de capteurs.</value>
+Laissez vide si vous n'utilisez pas de commandes et de capteurs.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="OnboardingMqtt_LblDiscoveryPrefix" xml:space="preserve">
     <value>Préfixe de découverte</value>
   </data>
   <data name="OnboardingMqtt_LblTip1" xml:space="preserve">
-    <value>(laisser par défaut si vous n&apos;êtes pas sûr)</value>
+    <value>(laisser par défaut si vous n'êtes pas sûr)</value>
   </data>
   <data name="OnboardingMqtt_LblTip2" xml:space="preserve">
     <value>Astuce : des paramètres spécialisés peuvent être trouvés dans la fenêtre Paramètres.</value>
@@ -502,7 +502,7 @@ Laissez vide si vous n&apos;utilisez pas de commandes et de capteurs.</value>
     <value>Combinaison de touches</value>
   </data>
   <data name="OnboardingHotKey_LblInfo1" xml:space="preserve">
-    <value>Un moyen simple d&apos;afficher vos actions rapides consiste à utiliser un raccourci clavier global.
+    <value>Un moyen simple d'afficher vos actions rapides consiste à utiliser un raccourci clavier global.
 
 De cette façon, quoi que vous fassiez sur votre machine, vous pouvez toujours interagir avec Home Assistant.</value>
   </data>
@@ -512,7 +512,7 @@ De cette façon, quoi que vous fassiez sur votre machine, vous pouvez toujours i
   <data name="OnboardingUpdates_LblInfo1" xml:space="preserve">
     <value>Si vous le souhaitez, HASS.Agent peut vérifier les mises à jour en arrière-plan.
 
-Vous recevrez une notification (une fois par mise à jour) , vous informant qu&apos;une nouvelle version est prête à être installée.
+Vous recevrez une notification (une fois par mise à jour) , vous informant qu'une nouvelle version est prête à être installée.
 
 Voulez-vous activer cette fonctionnalité ?</value>
     <comment>Fuzzy</comment>
@@ -521,23 +521,23 @@ Voulez-vous activer cette fonctionnalité ?</value>
     <value>Oui, informez moi des nouvelles mises à jour</value>
   </data>
   <data name="OnboardingUpdates_CbExecuteUpdater" xml:space="preserve">
-    <value>Oui, téléchargez et lancez l&apos;installation pour moi</value>
+    <value>Oui, téléchargez et lancez l'installation pour moi</value>
   </data>
   <data name="OnboardingUpdates_LblInfo2" xml:space="preserve">
-    <value>Lorsqu&apos;il y a une mise à jour, HASS.Agent offre la possibilité d&apos;ouvrir la page de publication. Mais si vous
-voulez, HASS.Agent peut également télécharger et lancer le programme d&apos;installation pour vous - encore moins à faire !
+    <value>Lorsqu'il y a une mise à jour, HASS.Agent offre la possibilité d'ouvrir la page de publication. Mais si vous
+voulez, HASS.Agent peut également télécharger et lancer le programme d'installation pour vous - encore moins à faire !
 
-Le certificat du fichier téléchargé sera vérifié. Vous verrez toujours une page avec les notes de version, et vous devrez toujours approuver manuellement - rien n&apos;est fait sans votre consentement.</value>
+Le certificat du fichier téléchargé sera vérifié. Vous verrez toujours une page avec les notes de version, et vous devrez toujours approuver manuellement - rien n'est fait sans votre consentement.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="OnboardingDone_LblGitHub" xml:space="preserve">
     <value>Page GitHub HASS.Agent</value>
   </data>
   <data name="OnboardingDone_LblInfo3" xml:space="preserve">
-    <value>Astuce : il y a beaucoup plus à tripatouiller, alors assurez-vous de jeter un coup d&apos;œil à la fenêtre de Paramètres !
+    <value>Astuce : il y a beaucoup plus à tripatouiller, alors assurez-vous de jeter un coup d'œil à la fenêtre de Paramètres !
 
 
-Merci d&apos;utiliser HASS.Agent, j&apos;espère que cela vous sera utile :-)</value>
+Merci d'utiliser HASS.Agent, j'espère que cela vous sera utile :-)</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="OnboardingDone_LblInfo2" xml:space="preserve">
@@ -583,7 +583,7 @@ Merci d&apos;utiliser HASS.Agent, j&apos;espère que cela vous sera utile :-)</v
     <value>Se connectez au service</value>
   </data>
   <data name="ServiceConnect_LblLoading" xml:space="preserve">
-    <value>Connexion avec le Service Windows, un instant s&apos;il vous plaît ..</value>
+    <value>Connexion avec le Service Windows, un instant s'il vous plaît ..</value>
   </data>
   <data name="ServiceConnect_LblFetchConfig" xml:space="preserve">
     <value>Récupérer les paramètres</value>
@@ -596,7 +596,7 @@ Merci d&apos;utiliser HASS.Agent, j&apos;espère que cela vous sera utile :-)</v
     <comment>Fuzzy</comment>
   </data>
   <data name="ServiceGeneral_LblDeviceName" xml:space="preserve">
-    <value>Nom de l&apos;appareil</value>
+    <value>Nom de l'appareil</value>
   </data>
   <data name="ServiceGeneral_LblTip1" xml:space="preserve">
     <value>Astuce : double-cliquez pour parcourir</value>
@@ -650,11 +650,11 @@ Merci d&apos;utiliser HASS.Agent, j&apos;espère que cela vous sera utile :-)</v
     <value>Effacer les paramètres</value>
   </data>
   <data name="ServiceMqtt_LblTip1" xml:space="preserve">
-    <value>(laisser par défaut si vous n&apos;êtes pas sûr)</value>
+    <value>(laisser par défaut si vous n'êtes pas sûr)</value>
   </data>
   <data name="ServiceMqtt_LblInfo1" xml:space="preserve">
-    <value>Les commandes et les capteurs sont envoyés via MQTT. Veuillez fournir les informations d&apos;identification de votre serveur. Si vous utilisez l&apos;addon HA,
-vous pouvez probablement utiliser l&apos;adresse prédéfinie.</value>
+    <value>Les commandes et les capteurs sont envoyés via MQTT. Veuillez fournir les informations d'identification de votre serveur. Si vous utilisez l'addon HA,
+vous pouvez probablement utiliser l'adresse prédéfinie.</value>
   </data>
   <data name="ServiceMqtt_LblDiscoPrefix" xml:space="preserve">
     <value>Préfixe de découverte</value>
@@ -663,13 +663,13 @@ vous pouvez probablement utiliser l&apos;adresse prédéfinie.</value>
     <value>Mot de passe</value>
   </data>
   <data name="ServiceMqtt_LblBrokerUsername" xml:space="preserve">
-    <value>Nom d&apos;utilisateur</value>
+    <value>Nom d'utilisateur</value>
   </data>
   <data name="ServiceMqtt_LblBrokerPort" xml:space="preserve">
     <value>Port</value>
   </data>
   <data name="ServiceMqtt_LblBrokerIp" xml:space="preserve">
-    <value>Adresse IP ou nom d&apos;hôte du broker</value>
+    <value>Adresse IP ou nom d'hôte du broker</value>
   </data>
   <data name="ServiceMqtt_BtnStore" xml:space="preserve">
     <value>Envoyer et activer la configuration</value>
@@ -738,7 +738,7 @@ vous pouvez probablement utiliser l&apos;adresse prédéfinie.</value>
     <value>Veuillez patienter un peu pendant que HASS.Agent redémarre ..</value>
   </data>
   <data name="Restart_LblTask1" xml:space="preserve">
-    <value>En attente de la fermeture de l&apos;instance précédente</value>
+    <value>En attente de la fermeture de l'instance précédente</value>
   </data>
   <data name="Restart_LblTask2" xml:space="preserve">
     <value>Relancer HASS.Agent</value>
@@ -771,7 +771,7 @@ vous pouvez probablement utiliser l&apos;adresse prédéfinie.</value>
     <value>Fermer</value>
   </data>
   <data name="CommandMqttTopic_LblInfo1" xml:space="preserve">
-    <value>Voici le topic MQTT sur lequel vous pouvez publier des commandes d&apos;action :</value>
+    <value>Voici le topic MQTT sur lequel vous pouvez publier des commandes d'action :</value>
   </data>
   <data name="CommandMqttTopic_BtnCopyClipboard" xml:space="preserve">
     <value>Copier dans le presse papier</value>
@@ -780,7 +780,7 @@ vous pouvez probablement utiliser l&apos;adresse prédéfinie.</value>
     <value>Aide et exemples</value>
   </data>
   <data name="CommandMqttTopic_Title" xml:space="preserve">
-    <value>Topic d&apos;Action MQTT</value>
+    <value>Topic d'Action MQTT</value>
   </data>
   <data name="CommandsConfig_BtnRemove" xml:space="preserve">
     <value>Supprimer</value>
@@ -823,10 +823,10 @@ vous pouvez probablement utiliser l&apos;adresse prédéfinie.</value>
     <value>Description</value>
   </data>
   <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
-    <value>Exécuter en &apos;faible intégrité&apos;</value>
+    <value>Exécuter en 'faible intégrité'</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
-    <value>Qu&apos;est ce que c&apos;est ?</value>
+    <value>Qu'est ce que c'est ?</value>
   </data>
   <data name="CommandsMod_ClmSensorName" xml:space="preserve">
     <value>  type</value>
@@ -844,10 +844,10 @@ vous pouvez probablement utiliser l&apos;adresse prédéfinie.</value>
     <value>hass.agent seulement !</value>
   </data>
   <data name="CommandsMod_LblEntityType" xml:space="preserve">
-    <value>Type d&apos;entité</value>
+    <value>Type d'entité</value>
   </data>
   <data name="CommandsMod_LblMqttTopic" xml:space="preserve">
-    <value>Afficher le topic d&apos;action MQTT</value>
+    <value>Afficher le topic d'action MQTT</value>
   </data>
   <data name="CommandsMod_LblActionInfo" xml:space="preserve">
     <value>Action</value>
@@ -899,7 +899,7 @@ vous pouvez probablement utiliser l&apos;adresse prédéfinie.</value>
     <value>Configuration des actions rapides</value>
   </data>
   <data name="QuickActionsMod_BtnStore" xml:space="preserve">
-    <value>Enregistrer l&apos;action rapide</value>
+    <value>Enregistrer l'action rapide</value>
   </data>
   <data name="QuickActionsMod_LblDomain" xml:space="preserve">
     <value>Domaine</value>
@@ -924,7 +924,7 @@ vous pouvez probablement utiliser l&apos;adresse prédéfinie.</value>
     <value>Combinaison de raccourcis</value>
   </data>
   <data name="QuickActionsMod_LblTip1" xml:space="preserve">
-    <value>(optionnel, sera utilisé à la place du nom de l&apos;entité)</value>
+    <value>(optionnel, sera utilisé à la place du nom de l'entité)</value>
   </data>
   <data name="QuickActionsMod_Title" xml:space="preserve">
     <value>Action Rapide</value>
@@ -1027,11 +1027,11 @@ vous pouvez probablement utiliser l&apos;adresse prédéfinie.</value>
 composants utilisés pour leurs licences individuelles :</value>
   </data>
   <data name="About_LblInfo4" xml:space="preserve">
-    <value>Un grand &apos;merci&apos; aux développeurs de ces projets, qui ont eu la gentillesse de partager
-leurs travails acharnés avec le reste d&apos;entre nous, simples mortels.</value>
+    <value>Un grand 'merci' aux développeurs de ces projets, qui ont eu la gentillesse de partager
+leurs travails acharnés avec le reste d'entre nous, simples mortels.</value>
   </data>
   <data name="About_LblInfo5" xml:space="preserve">
-    <value>Et bien sûr; merci à Paulus Shoutsen et à toute l&apos;équipe de développeurs qui 
+    <value>Et bien sûr; merci à Paulus Shoutsen et à toute l'équipe de développeurs qui 
 ont créé et maintiennent Home Assistant :-)</value>
   </data>
   <data name="About_LblInfo2" xml:space="preserve">
@@ -1050,7 +1050,7 @@ ont créé et maintiennent Home Assistant :-)</value>
     <value>Outils Externes</value>
   </data>
   <data name="Configuration_TabHassApi" xml:space="preserve">
-    <value>API d&apos;Home Assistant</value>
+    <value>API d'Home Assistant</value>
   </data>
   <data name="Configuration_TabHotKey" xml:space="preserve">
     <value>Raccourcis</value>
@@ -1111,7 +1111,7 @@ ont créé et maintiennent Home Assistant :-)</value>
     <value>fermer</value>
   </data>
   <data name="Help_LblInfo1" xml:space="preserve">
-    <value>Vous êtes bloqué lors de l&apos;utilisation de HASS.Agent, vous avez besoin d&apos;aide pour intégrer les capteurs/commandes ou vous avez une idée géniale pour la prochaine version ?
+    <value>Vous êtes bloqué lors de l'utilisation de HASS.Agent, vous avez besoin d'aide pour intégrer les capteurs/commandes ou vous avez une idée géniale pour la prochaine version ?
 
 Il existe plusieurs canaux par lesquels vous pouvez nous joindre :</value>
   </data>
@@ -1125,13 +1125,13 @@ Il existe plusieurs canaux par lesquels vous pouvez nous joindre :</value>
     <value>tickets GitHub</value>
   </data>
   <data name="Help_LblHAInfo" xml:space="preserve">
-    <value>Un peu de tout, avec en plus l&apos;aide d&apos;autres utilisateurs HA.</value>
+    <value>Un peu de tout, avec en plus l'aide d'autres utilisateurs HA.</value>
   </data>
   <data name="Help_LblGitHubInfo" xml:space="preserve">
     <value>Signaler des bugs, demande de fonctionnalités, idées, astuces, ..</value>
   </data>
   <data name="Help_LblDiscordInfo" xml:space="preserve">
-    <value>Obtenir de l&apos;aide sur le paramétrage et l&apos;utilisation de HASS.Agent, signaler des problèmes ou juste parler de différents sujets.</value>
+    <value>Obtenir de l'aide sur le paramétrage et l'utilisation de HASS.Agent, signaler des problèmes ou juste parler de différents sujets.</value>
   </data>
   <data name="Help_LblWikiInfo" xml:space="preserve">
     <value>Documentation et exemples.</value>
@@ -1214,7 +1214,7 @@ Il existe plusieurs canaux par lesquels vous pouvez nous joindre :</value>
     <value>Actions rapides :</value>
   </data>
   <data name="Main_LblHomeAssistantApi" xml:space="preserve">
-    <value>API d&apos;home assistant :</value>
+    <value>API d'home assistant :</value>
   </data>
   <data name="Main_LblNotificationApi" xml:space="preserve">
     <value>API de notification :</value>
@@ -1235,7 +1235,7 @@ Il existe plusieurs canaux par lesquels vous pouvez nous joindre :</value>
     <value>HASS.Agent Onboarding</value>
   </data>
   <data name="UpdatePending_BtnDownload" xml:space="preserve">
-    <value>une seconde, collecte d&apos;infos ..</value>
+    <value>une seconde, collecte d'infos ..</value>
   </data>
   <data name="UpdatePending_LblNewReleaseInfo" xml:space="preserve">
     <value>Il y a une nouvelle version disponible :</value>
@@ -1250,36 +1250,37 @@ Il existe plusieurs canaux par lesquels vous pouvez nous joindre :</value>
     <value>page des mises à jour</value>
   </data>
   <data name="UpdatePending_Title" xml:space="preserve">
-    <value>Mise à jour d&apos;HASS.Agent</value>
+    <value>Mise à jour d'HASS.Agent</value>
   </data>
   <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
     <value>Exécutez une commande personnalisée.
 
-Ces commandes s&apos;exécutent sans droits spéciaux. Pour exécuter en temps qu&apos;administrateur, créez une tâche planifiée et utilisez la ligne de commande &apos;schtasks /Run /TN &quot;TaskName&quot;&apos;  exécuter votre tâche.
+Ces commandes s'exécutent sans droits spéciaux. Pour exécuter en temps qu'administrateur, créez une tâche planifiée et utilisez la ligne de commande 'schtasks /Run /TN "TaskName"'  exécuter votre tâche.
 
-Ou utilisez &apos;Exécuter avec une faible intégrité&apos; pour une exécution encore plus stricte.</value>
+Ou utilisez 'Exécuter avec une faible intégrité' pour une exécution encore plus stricte.</value>
   </data>
   <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
     <value>Lancer la commande via le programme personnalisé défini (dans Paramètres -&gt; Outils Externes).
 
-Votre commande est passée en tant qu&apos;argument &apos;tel quel&apos;, vous devez donc fournir vos propres guillemets, etc. si nécessaire.</value>
+Votre commande est passée en tant qu'argument 'tel quel', vous devez donc fournir vos propres guillemets, etc. si nécessaire.</value>
   </data>
   <data name="CommandsManager_HibernateCommandDescription" xml:space="preserve">
     <value>Mettre Windows en veille prolongée</value>
   </data>
   <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
-    <value>Simule un appui sur une touche de clavier.
+    <value>Simule une seule pression de touche.
 
-Cliquez sur la zone de texte &quot;Code de touche&quot; et appuyez sur la touche que vous souhaitez simuler. Le code touche correspondant sera saisi pour vous.
+Cliquez sur la zone de texte "keycode" et appuyez sur la touche que vous souhaitez simuler. Le code clé correspondant sera saisi pour vous.
+Pour la touche TAB, veuillez utiliser LCTRL+TAB.
 
-Si vous avez besoin de plus de touches et/ou de combinaison tel que CTRL, utilisez la commande &quot;Séries de touche et combinaisons&quot;.</value>
+Si vous avez besoin de plus de touches et/ou de modificateurs comme CTRL, utilisez la commande MultipleKeys.</value>
   </data>
   <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
-    <value>Ouvre l&apos;URL fournie, par défaut dans votre navigateur par défaut.
+    <value>Ouvre l'URL fournie, par défaut dans votre navigateur par défaut.
 
-Pour utiliser le mode &apos;incognito&apos;, fournissez un navigateur spécifique dans Paramètres -&gt; Outils externes.
+Pour utiliser le mode 'incognito', fournissez un navigateur spécifique dans Paramètres -&gt; Outils externes.
 
-Si vous voulez juste une fenêtre avec une URL spécifique (pas le navigateur entier), utilisez une commande &apos;WebView&apos;.</value>
+Si vous voulez juste une fenêtre avec une URL spécifique (pas le navigateur entier), utilisez une commande 'WebView'.</value>
   </data>
   <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
     <value>Verrouiller la session.</value>
@@ -1288,27 +1289,27 @@ Si vous voulez juste une fenêtre avec une URL spécifique (pas le navigateur en
     <value>Se déconnecter de la session.</value>
   </data>
   <data name="CommandsManager_MediaMuteCommandDescription" xml:space="preserve">
-    <value>Simuler la touche &apos;mute&apos;</value>
+    <value>Simuler la touche 'mute'</value>
   </data>
   <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
-    <value>Simuler la touche &apos;Media suivant&apos;.</value>
+    <value>Simuler la touche 'Media suivant'.</value>
   </data>
   <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
-    <value>Simuler la touche &apos;lecture/pause du media&apos;.</value>
+    <value>Simuler la touche 'lecture/pause du media'.</value>
   </data>
   <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
-    <value>Simuler la touche &apos;Media précédent&apos;.</value>
+    <value>Simuler la touche 'Media précédent'.</value>
   </data>
   <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
-    <value>Simuler la touche &apos;Baisser le volume&apos;.</value>
+    <value>Simuler la touche 'Baisser le volume'.</value>
   </data>
   <data name="CommandsManager_MediaVolumeUpCommandDescription" xml:space="preserve">
-    <value>Simuler la touche &apos;Augmenter le volume&apos;.</value>
+    <value>Simuler la touche 'Augmenter le volume'.</value>
   </data>
   <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
-    <value>Simule l&apos;appui de plusieurs touches.
+    <value>Simule l'appui de plusieurs touches.
 
-Vous devez encadrer chaque touche ou combinaison de touches par des crochets [ ], sinon HASS.Agent ne peut pas les distinguer. Supposons que vous souhaitiez appuyer sur X, TAB, Y, et SHIFT-Z, ça s&apos;écrirai [X] [{TAB}] [Y] [+Z].
+Vous devez encadrer chaque touche ou combinaison de touches par des crochets [ ], sinon HASS.Agent ne peut pas les distinguer. Supposons que vous souhaitiez appuyer sur X, TAB, Y, et SHIFT-Z, ça s'écrirai [X] [{TAB}] [Y] [+Z].
 
 Il y a quelques astuces que vous pouvez utiliser :
 
@@ -1320,12 +1321,12 @@ Il y a quelques astuces que vous pouvez utiliser :
 
 - Pour plusieurs appuis, utilisez {z 15}, ce qui signifie que Z sera appuyé 15 fois.
 
-Plus d&apos;informations : https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys</value>
+Plus d'informations : https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys</value>
   </data>
   <data name="CommandsManager_PowershellCommandDescription" xml:space="preserve">
     <value>Exécutez une commande ou un script Powershell.
 
-Vous pouvez soit fournir l&apos;emplacement d&apos;un script (*.ps1), soit une seule ligne de commande.
+Vous pouvez soit fournir l'emplacement d'un script (*.ps1), soit une seule ligne de commande.
 
 Cela fonctionnera sans droits particuliers.</value>
   </data>
@@ -1337,44 +1338,44 @@ Utile par exemple si vous souhaitez forcer HASS.Agent à mettre à jour tous vos
   <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
     <value>Redémarre la machine après une minute.
 
-Astuce : déclenché accidentellement ? Exécutez la commande &apos;shutdown /a&apos; pour annuler.</value>
+Astuce : déclenché accidentellement ? Exécutez la commande 'shutdown /a' pour annuler.</value>
   </data>
   <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
     <value>Arrête la machine après une minute.
 
-Astuce : déclenché accidentellement ? Exécutez &apos;shutdown /a&apos; pour annuler.</value>
+Astuce : déclenché accidentellement ? Exécutez 'shutdown /a' pour annuler.</value>
   </data>
   <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
     <value>Met la machine en veille.
 
-Remarque : en raison d&apos;une limitation de Windows, cela ne fonctionne que si la veille prolongée est désactivée, sinon il se mettra en veille prolongée.
+Remarque : en raison d'une limitation de Windows, cela ne fonctionne que si la veille prolongée est désactivée, sinon il se mettra en veille prolongée.
 
 Vous pouvez utiliser un outil tel que NirCmd (http://www.nirsoft.net/utils/nircmd.html) pour contourner le problème.</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox1" xml:space="preserve">
-    <value>Veuillez saisir l&apos;emplacement de l&apos;exécutable de votre navigateur (fichier .exe).</value>
+    <value>Veuillez saisir l'emplacement de l'exécutable de votre navigateur (fichier .exe).</value>
   </data>
   <data name="ConfigExternalTools_ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox2" xml:space="preserve">
-    <value>L&apos;exécutable fourni est introuvable.</value>
+    <value>L'exécutable fourni est introuvable.</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox3" xml:space="preserve">
-    <value>Vous n&apos;avez indiqué aucun argument de navigation privée, le navigateur se lancera donc probablement normalement.
+    <value>Vous n'avez indiqué aucun argument de navigation privée, le navigateur se lancera donc probablement normalement.
 
 Voulez-vous continuer?</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox4" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors du lancement de votre navigateur en mode navigation privée.
+    <value>Une erreur s'est produite lors du lancement de votre navigateur en mode navigation privée.
 
-Consultez les journaux pour plus d&apos;informations.</value>
+Consultez les journaux pour plus d'informations.</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox1" xml:space="preserve">
-    <value>Merci d&apos;entrer une clef d&apos;API valide.</value>
+    <value>Merci d'entrer une clef d'API valide.</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox2" xml:space="preserve">
-    <value>Merci d&apos;entrer d&apos;adresse de votre Home Assistant.</value>
+    <value>Merci d'entrer d'adresse de votre Home Assistant.</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox3" xml:space="preserve">
-    <value>Impossible de se connecter, l&apos;erreur suivante a été renvoyée :
+    <value>Impossible de se connecter, l'erreur suivante a été renvoyée :
 
 {0}</value>
   </data>
@@ -1393,7 +1394,7 @@ Version de Home Assistant : {0}</value>
     <value>Les notifications sont toujours désactivées. Veuillez les activer, redémarrer HASS.Agent et réessayer.</value>
   </data>
   <data name="ConfigNotifications_BtnSendTestNotification_MessageBox2" xml:space="preserve">
-    <value>La notification doit être apparue. Si ce n&apos;est pas le cas, consultez les journaux ou lisez la documentation pour obtenir des conseils de dépannage.
+    <value>La notification doit être apparue. Si ce n'est pas le cas, consultez les journaux ou lisez la documentation pour obtenir des conseils de dépannage.
 
 Remarque : cela ne teste que localement si les notifications peuvent être affichées !</value>
   </data>
@@ -1401,14 +1402,14 @@ Remarque : cela ne teste que localement si les notifications peuvent être affic
     <value>Ceci est une notification de test.</value>
   </data>
   <data name="ConfigNotifications_BtnExecutePortReservation_Busy" xml:space="preserve">
-    <value>en cours d&apos;exécution, veuillez patienter ..</value>
+    <value>en cours d'exécution, veuillez patienter ..</value>
   </data>
   <data name="ConfigNotifications_BtnExecutePortReservation_MessageBox1" xml:space="preserve">
-    <value>Quelque chose s&apos;est mal passé !
+    <value>Quelque chose s'est mal passé !
 
 Veuillez exécuter manuellement la commande. Elle a été copiée dans votre presse-papiers, il vous suffit de le coller dans une invite de commande avec droits administrateurs.
 
-N&apos;oubliez pas de modifier également les règles de port du pare-feu.</value>
+N'oubliez pas de modifier également les règles de port du pare-feu.</value>
   </data>
   <data name="ConfigService_NotInstalled" xml:space="preserve">
     <value>Non installé</value>
@@ -1426,44 +1427,44 @@ N&apos;oubliez pas de modifier également les règles de port du pare-feu.</valu
     <value>Echoué</value>
   </data>
   <data name="ConfigService_BtnStopService_MessageBox1" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de la tentative d&apos;arrêt du service. Avez-vous autorisé l&apos;invite UAC ?
+    <value>Une erreur s'est produite lors de la tentative d'arrêt du service. Avez-vous autorisé l'invite UAC ?
 
-Consultez les journaux HASS.Agent (pas le service) pour plus d&apos;informations.</value>
+Consultez les journaux HASS.Agent (pas le service) pour plus d'informations.</value>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
-    <value>Le service est défini sur &apos;désactivé&apos;, il ne peut donc pas être démarré.
+    <value>Le service est défini sur 'désactivé', il ne peut donc pas être démarré.
 
-Veuillez d&apos;abord activer le service, puis réessayer.</value>
+Veuillez d'abord activer le service, puis réessayer.</value>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox2" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de la tentative de démarrage du service. Avez-vous autorisé l&apos;invite UAC ?
+    <value>Une erreur s'est produite lors de la tentative de démarrage du service. Avez-vous autorisé l'invite UAC ?
 
-Consultez les journaux HASS.Agent (pas le service) pour plus d&apos;informations.</value>
+Consultez les journaux HASS.Agent (pas le service) pour plus d'informations.</value>
   </data>
   <data name="ConfigService_BtnDisableService_MessageBox1" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de la tentative de désactivation du service. Avez-vous autorisé l&apos;invite UAC ?
+    <value>Une erreur s'est produite lors de la tentative de désactivation du service. Avez-vous autorisé l'invite UAC ?
 
-Consultez les journaux HASS.Agent (pas le service) pour plus d&apos;informations.</value>
+Consultez les journaux HASS.Agent (pas le service) pour plus d'informations.</value>
   </data>
   <data name="ConfigService_BtnEnableService_MessageBox1" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de la tentative d&apos;activation du service. Avez-vous autorisé l&apos;invite UAC ?
+    <value>Une erreur s'est produite lors de la tentative d'activation du service. Avez-vous autorisé l'invite UAC ?
 
-Consultez les journaux HASS.Agent (pas le service) pour plus d&apos;informations.</value>
+Consultez les journaux HASS.Agent (pas le service) pour plus d'informations.</value>
   </data>
   <data name="ConfigService_BtnShowLogs_MessageBox1" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de la tentative de réinstallation du service. Avez-vous autorisé l&apos;invite UAC ?
+    <value>Une erreur s'est produite lors de la tentative de réinstallation du service. Avez-vous autorisé l'invite UAC ?
 
-Consultez les journaux HASS.Agent (pas le service) pour plus d&apos;informations.</value>
+Consultez les journaux HASS.Agent (pas le service) pour plus d'informations.</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox1" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de la désactivation du démarrage à l&apos;ouverture de session.
+    <value>Une erreur s'est produite lors de la désactivation du démarrage à l'ouverture de session.
 
-Consultez les journaux pour plus d&apos;informations.</value>
+Consultez les journaux pour plus d'informations.</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin_MessageBox2" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de l&apos;activation du démarrage à l&apos;ouverture de session.
+    <value>Une erreur s'est produite lors de l'activation du démarrage à l'ouverture de session.
 
-Consultez les journaux pour plus d&apos;informations.</value>
+Consultez les journaux pour plus d'informations.</value>
   </data>
   <data name="ConfigStartup_Enabled" xml:space="preserve">
     <value>Activé</value>
@@ -1478,31 +1479,31 @@ Consultez les journaux pour plus d&apos;informations.</value>
     <value>Activer</value>
   </data>
   <data name="OnboardingStartup_Activated" xml:space="preserve">
-    <value>Démarrage à l&apos;ouverture de session activé !</value>
+    <value>Démarrage à l'ouverture de session activé !</value>
   </data>
   <data name="OnboardingStartup_EnableNow" xml:space="preserve">
-    <value>Voulez-vous activer le lancement à l&apos;ouverture de session maintenant ?</value>
+    <value>Voulez-vous activer le lancement à l'ouverture de session maintenant ?</value>
   </data>
   <data name="OnboardingStartup_AlreadyActivated" xml:space="preserve">
-    <value>Le lancement à l&apos;ouverture de session est activé !</value>
+    <value>Le lancement à l'ouverture de session est activé !</value>
   </data>
   <data name="OnboardingStartup_Activating" xml:space="preserve">
-    <value>Activation du lancement à l&apos;ouverture de session, patientez ..</value>
+    <value>Activation du lancement à l'ouverture de session, patientez ..</value>
   </data>
   <data name="OnboardingStartup_Failed" xml:space="preserve">
-    <value>Une erreur s&apos;est produite. Vous pouvez réessayer, ou passer à la page suivante et réessayer après le redémarrage de HASS.Agent.</value>
+    <value>Une erreur s'est produite. Vous pouvez réessayer, ou passer à la page suivante et réessayer après le redémarrage de HASS.Agent.</value>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin_2" xml:space="preserve">
-    <value>Activer le lancement à l&apos;ouverture de session</value>
+    <value>Activer le lancement à l'ouverture de session</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox1" xml:space="preserve">
     <value>Veuillez saisir une clé API valide.</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox2" xml:space="preserve">
-    <value>Veuillez saisir l&apos;adresse de votre Home Assistant.</value>
+    <value>Veuillez saisir l'adresse de votre Home Assistant.</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox3" xml:space="preserve">
-    <value>Impossible de se connecter, l&apos;erreur suivante a été renvoyée :
+    <value>Impossible de se connecter, l'erreur suivante a été renvoyée :
 
 {0}</value>
   </data>
@@ -1515,27 +1516,27 @@ Home Assistant version: {0}</value>
     <value>test en cours ..</value>
   </data>
   <data name="ServiceCommands_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de l&apos;enregistrement des commandes, consultez les journaux pour plus d&apos;informations.</value>
+    <value>Une erreur s'est produite lors de l'enregistrement des commandes, consultez les journaux pour plus d'informations.</value>
   </data>
   <data name="ServiceCommands_BtnStore_Storing" xml:space="preserve">
     <value>Enregistrement et connexion, veuillez patienter ..</value>
   </data>
   <data name="ServiceConnect_Connecting" xml:space="preserve">
-    <value>Connexion avec le Service Windows, un instant s&apos;il vous plaît ..</value>
+    <value>Connexion avec le Service Windows, un instant s'il vous plaît ..</value>
   </data>
   <data name="ServiceConnect_Failed" xml:space="preserve">
     <value>La connexion au service a échoué</value>
   </data>
   <data name="ServiceConnect_FailedMessage" xml:space="preserve">
-    <value>Le service n&apos;a pas été trouvé ! Vous pouvez l&apos;installer et le gérer à partir du panneau de configuration.
+    <value>Le service n'a pas été trouvé ! Vous pouvez l'installer et le gérer à partir du panneau de configuration.
 
-Lorsqu&apos;il est opérationnel, revenez ici pour configurer les commandes et les capteurs.</value>
+Lorsqu'il est opérationnel, revenez ici pour configurer les commandes et les capteurs.</value>
   </data>
   <data name="ServiceConnect_CommunicationFailed" xml:space="preserve">
     <value>La communication avec le service a échoué</value>
   </data>
   <data name="ServiceConnect_CommunicationFailedMessage" xml:space="preserve">
-    <value>Impossible de communiquer avec le service. Consultez les journaux pour plus d&apos;informations.
+    <value>Impossible de communiquer avec le service. Consultez les journaux pour plus d'informations.
 
 Vous pouvez ouvrir les journaux et gérer le service à partir de la fenêtre de paramètres.</value>
   </data>
@@ -1543,15 +1544,15 @@ Vous pouvez ouvrir les journaux et gérer le service à partir de la fenêtre de
     <value>Non autorisé</value>
   </data>
   <data name="ServiceConnect_UnauthorizedMessage" xml:space="preserve">
-    <value>Vous n&apos;êtes pas autorisé à vous connecter au service.
+    <value>Vous n'êtes pas autorisé à vous connecter au service.
 
-Si vous disposez d&apos;un identifiant de connexion valide, vous pouvez le saisir maintenant et réessayer.</value>
+Si vous disposez d'un identifiant de connexion valide, vous pouvez le saisir maintenant et réessayer.</value>
   </data>
   <data name="ServiceConnect_SettingsFailed" xml:space="preserve">
     <value>La récupération des paramètres a échoué</value>
   </data>
   <data name="ServiceConnect_SettingsFailedMessage" xml:space="preserve">
-    <value>Le service a renvoyé une erreur lors de la récupération de ses paramètres. Consultez les journaux pour plus d&apos;informations.
+    <value>Le service a renvoyé une erreur lors de la récupération de ses paramètres. Consultez les journaux pour plus d'informations.
 
 Vous pouvez ouvrir les journaux et gérer le service à partir de la fenêtre de paramètres.</value>
   </data>
@@ -1559,7 +1560,7 @@ Vous pouvez ouvrir les journaux et gérer le service à partir de la fenêtre de
     <value>La récupération des paramètres MQTT a échoué</value>
   </data>
   <data name="ServiceConnect_MqttFailedMessage" xml:space="preserve">
-    <value>Le service a renvoyé une erreur lors de la récupération des paramètres MQTT. Consultez les journaux pour plus d&apos;informations.
+    <value>Le service a renvoyé une erreur lors de la récupération des paramètres MQTT. Consultez les journaux pour plus d'informations.
 
 Vous pouvez ouvrir les journaux et gérer le service à partir de la fenêtre de paramètres.</value>
   </data>
@@ -1567,7 +1568,7 @@ Vous pouvez ouvrir les journaux et gérer le service à partir de la fenêtre de
     <value>La récupération des commandes configurées a échoué</value>
   </data>
   <data name="ServiceConnect_CommandsFailedMessage" xml:space="preserve">
-    <value>Le service a renvoyé une erreur lors de la récupération des commandes configurées. Consultez les journaux pour plus d&apos;informations.
+    <value>Le service a renvoyé une erreur lors de la récupération des commandes configurées. Consultez les journaux pour plus d'informations.
 
 Vous pouvez ouvrir les journaux et gérer le service à partir de la fenêtre de paramètres.</value>
   </data>
@@ -1575,24 +1576,24 @@ Vous pouvez ouvrir les journaux et gérer le service à partir de la fenêtre de
     <value>La récupération des capteurs configurés a échoué</value>
   </data>
   <data name="ServiceConnect_SensorsFailedMessage" xml:space="preserve">
-    <value>Le service a renvoyé une erreur lors de la récupération des capteurs configurés. Consultez les journaux pour plus d&apos;informations.
+    <value>Le service a renvoyé une erreur lors de la récupération des capteurs configurés. Consultez les journaux pour plus d'informations.
 
 Vous pouvez ouvrir les journaux et gérer le service à partir de la fenêtre de paramètres.</value>
   </data>
   <data name="ServiceGeneral_TbAuthId_MessageBox1" xml:space="preserve">
-    <value>La sauvegarde d&apos;identifiant d&apos;authentification vide permettra à tous les HASS.Agents d&apos;accéder au serveur.
+    <value>La sauvegarde d'identifiant d'authentification vide permettra à tous les HASS.Agents d'accéder au serveur.
 
 Êtes-vous sûr de vouloir cela ?</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ServiceGeneral_SavingFailedMessageBox" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de l&apos;enregistrement, consultez les journaux pour plus d&apos;informations.</value>
+    <value>Une erreur s'est produite lors de l'enregistrement, consultez les journaux pour plus d'informations.</value>
   </data>
   <data name="ServiceGeneral_BtnStoreDeviceName_MessageBox1" xml:space="preserve">
-    <value>Veuillez d&apos;abord saisir un nom d&apos;appareil.</value>
+    <value>Veuillez d'abord saisir un nom d'appareil.</value>
   </data>
   <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox1" xml:space="preserve">
-    <value>Veuillez d&apos;abord sélectionner un programme (astuce : double-cliquez pour parcourir).</value>
+    <value>Veuillez d'abord sélectionner un programme (astuce : double-cliquez pour parcourir).</value>
   </data>
   <data name="ServiceGeneral_BtnStoreCustomExecutor_MessageBox2" xml:space="preserve">
     <value>Le programme sélectionné est introuvable. Veuillez en sélectionner un nouveau.</value>
@@ -1605,41 +1606,41 @@ Seules les instances ayant le bon identifiant peuvent se connecter.
 Laissez vide pour permettre à tous de se connecter.</value>
   </data>
   <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
-    <value>C&apos;est le nom avec lequel le Service Windows s&apos;enregistre sur Home Assistant.
+    <value>C'est le nom avec lequel le Service Windows s'enregistre sur Home Assistant.
 
-Par défaut, c&apos;est le nom de votre PC suivi de &apos;-satellite&apos;.</value>
+Par défaut, c'est le nom de votre PC suivi de '-satellite'.</value>
   </data>
   <data name="ServiceGeneral_LblDisconGraceInfo_MessageBox1" xml:space="preserve">
-    <value>Le délai qu&apos;attendra le Service Windows avant de signaler une connexion perdue au broker MQTT.</value>
+    <value>Le délai qu'attendra le Service Windows avant de signaler une connexion perdue au broker MQTT.</value>
   </data>
   <data name="ServiceMqtt_StatusError" xml:space="preserve">
-    <value>Erreur lors de la récupération de l&apos;état, vérifier les journaux</value>
+    <value>Erreur lors de la récupération de l'état, vérifier les journaux</value>
   </data>
   <data name="ServiceMqtt_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de l&apos;enregistrement de la configuration, consultez les journaux pour plus d&apos;informations.</value>
+    <value>Une erreur s'est produite lors de l'enregistrement de la configuration, consultez les journaux pour plus d'informations.</value>
   </data>
   <data name="ServiceMqtt_BtnStore_Storing" xml:space="preserve">
     <value>enregistrement et connexion, veuillez patienter .. </value>
   </data>
   <data name="ServiceSensors_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de l&apos;enregistrement des capteurs, consultez les journaux pour plus d&apos;informations.</value>
+    <value>Une erreur s'est produite lors de l'enregistrement des capteurs, consultez les journaux pour plus d'informations.</value>
   </data>
   <data name="ServiceSensors_BtnStore_Storing" xml:space="preserve">
     <value>enregistrement et connexion, veuillez patienter .. </value>
   </data>
   <data name="PortReservation_ProcessPostUpdate_MessageBox1" xml:space="preserve">
-    <value>Les étapes n&apos;ont pas toutes été terminées avec succès. Veuillez consulter les journaux pour plus d&apos;informations.</value>
+    <value>Les étapes n'ont pas toutes été terminées avec succès. Veuillez consulter les journaux pour plus d'informations.</value>
   </data>
   <data name="PostUpdate_ProcessPostUpdate_MessageBox1" xml:space="preserve">
-    <value>Les étapes n&apos;ont pas toutes été terminées avec succès. Veuillez consulter les journaux pour plus d&apos;informations.</value>
+    <value>Les étapes n'ont pas toutes été terminées avec succès. Veuillez consulter les journaux pour plus d'informations.</value>
   </data>
   <data name="Restart_ProcessRestart_MessageBox1" xml:space="preserve">
     <value>HASS.Agent est toujours actif après {0} secondes. Veuillez fermer toutes les instances et redémarrer manuellement.
 
-Consultez les journaux pour plus d&apos;informations et informez éventuellement les développeurs.</value>
+Consultez les journaux pour plus d'informations et informez éventuellement les développeurs.</value>
   </data>
   <data name="ServiceReinstall_ProcessReinstall_MessageBox1" xml:space="preserve">
-    <value>Toutes les étapes ne sont pas terminées avec succès. Veuillez consulter les logs pour plus d&apos;informations.</value>
+    <value>Toutes les étapes ne sont pas terminées avec succès. Veuillez consulter les logs pour plus d'informations.</value>
   </data>
   <data name="ServiceSetState_Enabled" xml:space="preserve">
     <value>Activer le Service Windows</value>
@@ -1654,9 +1655,9 @@ Consultez les journaux pour plus d&apos;informations et informez éventuellement
     <value>Arrêter le Service Windows</value>
   </data>
   <data name="ServiceSetState_ProcessState_MessageBox1" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors du changement d&apos;état du service.
+    <value>Une erreur s'est produite lors du changement d'état du service.
 
-Veuillez consulter les journaux pour plus d&apos;informations.</value>
+Veuillez consulter les journaux pour plus d'informations.</value>
   </data>
   <data name="CommandMqttTopic_BtnCopyClipboard_Copied" xml:space="preserve">
     <value>topic copié dans le presse-papier</value>
@@ -1665,7 +1666,7 @@ Veuillez consulter les journaux pour plus d&apos;informations.</value>
     <value>enregistrement et connexion, veuillez patienter .. </value>
   </data>
   <data name="CommandsConfig_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de l&apos;enregistrement des commandes, consultez les logs pour plus d&apos;informations.</value>
+    <value>Une erreur s'est produite lors de l'enregistrement des commandes, consultez les logs pour plus d'informations.</value>
   </data>
   <data name="CommandsMod_Title_NewCommand" xml:space="preserve">
     <value>Nouvelle commande</value>
@@ -1680,7 +1681,7 @@ Veuillez consulter les journaux pour plus d&apos;informations.</value>
     <value>Sélectionner un type de commande valide.</value>
   </data>
   <data name="CommandsMod_MessageBox_EntityType" xml:space="preserve">
-    <value>Sélectionner un type d&apos;entité valide.</value>
+    <value>Sélectionner un type d'entité valide.</value>
   </data>
   <data name="CommandsMod_MessageBox_Name" xml:space="preserve">
     <value>Entrer un nom.</value>
@@ -1689,12 +1690,12 @@ Veuillez consulter les journaux pour plus d&apos;informations.</value>
     <value>Il existe déjà une commande portant ce nom. Etes-vous sur de vouloir continuer?</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox4" xml:space="preserve">
-    <value>Si vous n&apos;entrez pas de commande, vous ne pouvez utiliser cette entité qu&apos;avec une valeur &quot;action&quot; via Home Assistant. Le faire fonctionner tel quel ne fera rien.
+    <value>Si vous n'entrez pas de commande, vous ne pouvez utiliser cette entité qu'avec une valeur "action" via Home Assistant. Le faire fonctionner tel quel ne fera rien.
 
 Êtes-vous sûr de vouloir cela ?</value>
   </data>
   <data name="CommandsMod_MessageBox_Action" xml:space="preserve">
-    <value>Si vous n&apos;entrez pas de commande ou de script, vous ne pouvez utiliser cette entité qu&apos;avec une valeur &quot;action&quot; via Home Assistant. Le faire fonctionner tel quel ne fera rien.
+    <value>Si vous n'entrez pas de commande ou de script, vous ne pouvez utiliser cette entité qu'avec une valeur "action" via Home Assistant. Le faire fonctionner tel quel ne fera rien.
 
 Êtes-vous sûr de vouloir cela ?</value>
   </data>
@@ -1705,7 +1706,7 @@ Veuillez consulter les journaux pour plus d&apos;informations.</value>
     <value>La vérification des clés a échoué : {0}</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
-    <value>Si vous ne saisissez pas d&apos;URL, vous ne pouvez utiliser cette entité qu&apos;avec une valeur &quot;action&quot; via Home Assistant. Le faire fonctionner tel quel ne fera rien.
+    <value>Si vous ne saisissez pas d'URL, vous ne pouvez utiliser cette entité qu'avec une valeur "action" via Home Assistant. Le faire fonctionner tel quel ne fera rien.
 
 Êtes-vous sûr de vouloir cela ?</value>
   </data>
@@ -1748,46 +1749,46 @@ veuillez configurer un interpréteur de commandes ou votre commande ne fonctionn
     <value>Une faible intégrité signifie que votre commande sera exécutée avec des privilèges restreints.</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg2" xml:space="preserve">
-    <value>Cela signifie qu&apos;il ne pourra enregistrer et modifier des fichiers qu&apos;à certains endroits,</value>
+    <value>Cela signifie qu'il ne pourra enregistrer et modifier des fichiers qu'à certains endroits,</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
-    <value>comme le dossier &apos;%USERPROFILE%\AppData\LocalLow&apos; ou</value>
+    <value>comme le dossier '%USERPROFILE%\AppData\LocalLow' ou</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
-    <value>la clé de registre &apos;HKEY_CURRENT_USER\Software\AppDataLow&apos;.</value>
+    <value>la clé de registre 'HKEY_CURRENT_USER\Software\AppDataLow'.</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
-    <value>Vous devriez tester votre commande pour vous assurer qu&apos;elle n&apos;est pas influencée par cela.</value>
+    <value>Vous devriez tester votre commande pour vous assurer qu'elle n'est pas influencée par cela.</value>
   </data>
   <data name="CommandsMod_SpecificClient" xml:space="preserve">
     <value>{0} seulement !</value>
   </data>
   <data name="CommandsMod_LblMqttTopic_MessageBox1" xml:space="preserve">
-    <value>Le gestionnaire MQTT n&apos;a pas été correctement configuré ou n&apos;a pas encore terminé son démarrage.</value>
+    <value>Le gestionnaire MQTT n'a pas été correctement configuré ou n'a pas encore terminé son démarrage.</value>
   </data>
   <data name="QuickActions_CheckHassManager_MessageBox1" xml:space="preserve">
-    <value>Impossible de récupérer vos entités en raison d&apos;une configuration manquante, veuillez saisir les valeurs requises dans l&apos;écran de configuration.</value>
+    <value>Impossible de récupérer vos entités en raison d'une configuration manquante, veuillez saisir les valeurs requises dans l'écran de configuration.</value>
   </data>
   <data name="QuickActions_MessageBox_EntityFailed" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de la tentative de récupération de vos entités.</value>
+    <value>Une erreur s'est produite lors de la tentative de récupération de vos entités.</value>
   </data>
   <data name="QuickActionsMod_Title_New" xml:space="preserve">
     <value>Nouvelle Action Rapide</value>
   </data>
   <data name="QuickActionsMod_Title_Mod" xml:space="preserve">
-    <value>Modification de l&apos;action rapide</value>
+    <value>Modification de l'action rapide</value>
   </data>
   <data name="QuickActionsMod_CheckHassManager_MessageBox1" xml:space="preserve">
-    <value>Impossible de récupérer vos entités en raison d&apos;une configuration manquante, veuillez saisir les valeurs requises dans l&apos;écran de configuration.</value>
+    <value>Impossible de récupérer vos entités en raison d'une configuration manquante, veuillez saisir les valeurs requises dans l'écran de configuration.</value>
   </data>
   <data name="QuickActionsMod_MessageBox_Entities" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de la tentative de récupération de vos entités.</value>
+    <value>Une erreur s'est produite lors de la tentative de récupération de vos entités.</value>
   </data>
   <data name="QuickActionsMod_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Sélectionnez d&apos;abord une entité.</value>
+    <value>Sélectionnez d'abord une entité.</value>
   </data>
   <data name="QuickActionsMod_BtnStore_MessageBox2" xml:space="preserve">
-    <value>Sélectionnez d&apos;abord un domaine.</value>
+    <value>Sélectionnez d'abord un domaine.</value>
   </data>
   <data name="QuickActionsMod_BtnStore_MessageBox3" xml:space="preserve">
     <value>Action inconnue, veuillez en sélectionner une valide.</value>
@@ -1796,7 +1797,7 @@ veuillez configurer un interpréteur de commandes ou votre commande ne fonctionn
     <value>enregistrement et connexion, veuillez patienter .. </value>
   </data>
   <data name="SensorsConfig_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de l&apos;enregistrement des capteurs, consultez les journaux pour plus d&apos;informations.</value>
+    <value>Une erreur s'est produite lors de l'enregistrement des capteurs, consultez les journaux pour plus d'informations.</value>
   </data>
   <data name="SensorsMod_Title_New" xml:space="preserve">
     <value>Nouveau capteur</value>
@@ -1829,13 +1830,13 @@ veuillez configurer un interpréteur de commandes ou votre commande ne fonctionn
     <value>Service</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Sélectionnez d&apos;abord un type de capteur.</value>
+    <value>Sélectionnez d'abord un type de capteur.</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox2" xml:space="preserve">
-    <value>Sélectionnez d&apos;abord un type de capteur valide.</value>
+    <value>Sélectionnez d'abord un type de capteur valide.</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox3" xml:space="preserve">
-    <value>Entrez d&apos;abord un nom.</value>
+    <value>Entrez d'abord un nom.</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox4" xml:space="preserve">
     <value>Il existe déjà un capteur à valeur unique portant ce nom. Voulez-vous vraiment continuer ?</value>
@@ -1844,22 +1845,22 @@ veuillez configurer un interpréteur de commandes ou votre commande ne fonctionn
     <value>Il existe déjà un capteur à valeur multiple portant ce nom. Voulez-vous vraiment continuer ?</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox6" xml:space="preserve">
-    <value>Entrez d&apos;abord un intervalle entre 1 et 43200 (12 heures).</value>
+    <value>Entrez d'abord un intervalle entre 1 et 43200 (12 heures).</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox7" xml:space="preserve">
-    <value>Entrez d&apos;abord un nom de fenêtre.</value>
+    <value>Entrez d'abord un nom de fenêtre.</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox8" xml:space="preserve">
-    <value>Saisissez d&apos;abord une requête.</value>
+    <value>Saisissez d'abord une requête.</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox9" xml:space="preserve">
-    <value>Entrez d&apos;abord une catégorie et une instance.</value>
+    <value>Entrez d'abord une catégorie et une instance.</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox10" xml:space="preserve">
-    <value>Entrez d&apos;abord le nom d&apos;un processus.</value>
+    <value>Entrez d'abord le nom d'un processus.</value>
   </data>
   <data name="SensorsMod_BtnStore_MessageBox11" xml:space="preserve">
-    <value>Saisissez d&apos;abord le nom d&apos;un service.</value>
+    <value>Saisissez d'abord le nom d'un service.</value>
   </data>
   <data name="SensorsMod_SpecificClient" xml:space="preserve">
     <value>{0} seulement !</value>
@@ -1871,20 +1872,20 @@ Tous vos capteurs et commandes seront désormais dépubliés, et HASS.Agent red�
 
 Ne vous inquiétez pas, ils conserveront leur nom actuel, de sorte que vos automatisations ou scripts continueront de fonctionner.
 
-Remarque : le nom sera &apos;nettoyé&apos;, ce qui signifie que tout, sauf les lettres, les chiffres et les espaces, sera remplacé par un trait de soulignement. Ceci est requis par HA.</value>
+Remarque : le nom sera 'nettoyé', ce qui signifie que tout, sauf les lettres, les chiffres et les espaces, sera remplacé par un trait de soulignement. Ceci est requis par HA.</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox2" xml:space="preserve">
-    <value>Vous avez modifié le port de l&apos;API de notification. Ce nouveau port doit être réservé.
+    <value>Vous avez modifié le port de l'API de notification. Ce nouveau port doit être réservé.
 
 Vous recevrez une demande UAC pour le faire, veuillez approuver.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox3" xml:space="preserve">
-    <value>Quelque chose s&apos;est mal passé !
+    <value>Quelque chose s'est mal passé !
 
 Veuillez exécuter manuellement la commande. Elle a été copié dans votre presse-papiers, il vous suffit de la coller dans une invite de commande en mode administrateur.
 
-N&apos;oubliez pas de modifier également le port dans la règle du pare-feu.</value>
+N'oubliez pas de modifier également le port dans la règle du pare-feu.</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox4" xml:space="preserve">
     <value>Le port a été réservé avec succès !
@@ -1892,7 +1893,7 @@ N&apos;oubliez pas de modifier également le port dans la règle du pare-feu.</v
 HASS.Agent va maintenant redémarrer pour activer la nouvelle configuration.</value>
   </data>
   <data name="Configuration_MessageBox_RestartManually" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de la préparation du redémarrage.
+    <value>Une erreur s'est produite lors de la préparation du redémarrage.
 Veuillez redémarrer manuellement.</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox5" xml:space="preserve">
@@ -1901,13 +1902,13 @@ Veuillez redémarrer manuellement.</value>
 Voulez-vous redémarrer maintenant ?</value>
   </data>
   <data name="Main_Load_MessageBox1" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors du chargement de vos paramètres.
+    <value>Une erreur s'est produite lors du chargement de vos paramètres.
 
-Vérifiez appsettings.json dans le sous-dossier &apos;Config&apos;, ou supprimez le simplement pour recommencer à zéro.</value>
+Vérifiez appsettings.json dans le sous-dossier 'Config', ou supprimez le simplement pour recommencer à zéro.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="Main_Load_MessageBox2" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors du lancement de HASS.Agent.
+    <value>Une erreur s'est produite lors du lancement de HASS.Agent.
 Veuillez vérifier les journaux et faire un rapport de bug sur github.</value>
     <comment>Fuzzy</comment>
   </data>
@@ -1931,7 +1932,7 @@ Veuillez vérifier les journaux et faire un rapport de bug sur github.</value>
     <value>Mise à jour HASS.Agent BETA</value>
   </data>
   <data name="UpdatePending_LblUpdateQuestion_Download" xml:space="preserve">
-    <value>Voulez-vous télécharger et lancer le programme d&apos;installation ?</value>
+    <value>Voulez-vous télécharger et lancer le programme d'installation ?</value>
   </data>
   <data name="UpdatePending_LblUpdateQuestion_Navigate" xml:space="preserve">
     <value>Voulez-vous accéder à la page des releases ?</value>
@@ -1982,7 +1983,7 @@ Veuillez vérifier les journaux et faire un rapport de bug sur github.</value>
     <value>HASS.Agent intégration : Terminée [{0}/{1}]</value>
   </data>
   <data name="OnboardingManager_ConfirmBeforeClose_MessageBox1" xml:space="preserve">
-    <value>Voulez-vous vraiment abandonner le processus d&apos;intégration ?
+    <value>Voulez-vous vraiment abandonner le processus d'intégration ?
 
 Votre progression ne sera pas enregistrée et ne sera plus affichée au prochain lancement.</value>
   </data>
@@ -1990,26 +1991,26 @@ Votre progression ne sera pas enregistrée et ne sera plus affichée au prochain
     <value>Erreur lors de la récupération des informations, vérifiez les journaux</value>
   </data>
   <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox1" xml:space="preserve">
-    <value>Impossible de préparer le téléchargement de la mise à jour, consultez les journaux pour plus d&apos;informations.
+    <value>Impossible de préparer le téléchargement de la mise à jour, consultez les journaux pour plus d'informations.
 
-La page de mise à jour s&apos;ouvrira maintenant à la place.</value>
+La page de mise à jour s'ouvrira maintenant à la place.</value>
   </data>
   <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox2" xml:space="preserve">
-    <value>Impossible de télécharger la mise à jour, consultez les journaux pour plus d&apos;informations.
+    <value>Impossible de télécharger la mise à jour, consultez les journaux pour plus d'informations.
 
-La page de mise à jour s&apos;ouvrira maintenant à la place.</value>
+La page de mise à jour s'ouvrira maintenant à la place.</value>
   </data>
   <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox3" xml:space="preserve">
-    <value>Le fichier téléchargé n&apos;a pas pu être vérifié.
+    <value>Le fichier téléchargé n'a pas pu être vérifié.
 
-Il peut s&apos;agir d&apos;une erreur technique, mais aussi d&apos;un fichier trafiqué !
+Il peut s'agir d'une erreur technique, mais aussi d'un fichier trafiqué !
 
 Veuillez vérifier les journaux et poster un ticket avec les résultats.</value>
   </data>
   <data name="UpdateManager_DownloadAndExecuteUpdate_MessageBox4" xml:space="preserve">
-    <value>Impossible de lancer le programme d&apos;installation (avez-vous approuvé l&apos;invite UAC ?), consultez les journaux pour plus d&apos;informations.
+    <value>Impossible de lancer le programme d'installation (avez-vous approuvé l'invite UAC ?), consultez les journaux pour plus d'informations.
 
-La page de mise à jour s&apos;ouvrira maintenant à la place.</value>
+La page de mise à jour s'ouvrira maintenant à la place.</value>
   </data>
   <data name="HassApiManager_ToolTip_ConnectionSetupFailed" xml:space="preserve">
     <value>HASS API : échec de la configuration de la connexion</value>
@@ -2024,19 +2025,19 @@ La page de mise à jour s&apos;ouvrira maintenant à la place.</value>
     <value>Fichier de certificat client introuvable</value>
   </data>
   <data name="HassApiManager_CheckHassConfig_UnableToConnect" xml:space="preserve">
-    <value>Impossible de se connecter, vérifier l&apos;adresse</value>
+    <value>Impossible de se connecter, vérifier l'adresse</value>
   </data>
   <data name="HassApiManager_CheckHassConfig_ConfigFailed" xml:space="preserve">
     <value>Impossible de récupérer la configuration, vérifiez la clé API</value>
   </data>
   <data name="HassApiManager_ConnectionFailed" xml:space="preserve">
-    <value>Impossible de se connecter, vérifiez l&apos;adresse et la configuration</value>
+    <value>Impossible de se connecter, vérifiez l'adresse et la configuration</value>
   </data>
   <data name="HassApiManager_ToolTip_QuickActionFailed" xml:space="preserve">
-    <value>Action Rapide : échec de l&apos;action, consultez les journaux pour plus d&apos;informations</value>
+    <value>Action Rapide : échec de l'action, consultez les journaux pour plus d'informations</value>
   </data>
   <data name="HassApiManager_ToolTip_QuickActionFailedOnEntity" xml:space="preserve">
-    <value>Action Rapide : échec de l&apos;action, entité introuvable</value>
+    <value>Action Rapide : échec de l'action, entité introuvable</value>
   </data>
   <data name="MqttManager_ToolTip_ConnectionError" xml:space="preserve">
     <value>MQTT : erreur lors de la connexion</value>
@@ -2048,31 +2049,31 @@ La page de mise à jour s&apos;ouvrira maintenant à la place.</value>
     <value>MQTT: déconnecté</value>
   </data>
   <data name="NotifierManager_Initialize_MessageBox1" xml:space="preserve">
-    <value>Erreur lors de la tentative d&apos;appairage de l&apos;API au port {0}.
+    <value>Erreur lors de la tentative d'appairage de l'API au port {0}.
 
-Assurez-vous qu&apos;aucune autre instance de HASS.Agent n&apos;est en cours d&apos;exécution et que le port est disponible et enregistré.</value>
+Assurez-vous qu'aucune autre instance de HASS.Agent n'est en cours d'exécution et que le port est disponible et enregistré.</value>
   </data>
   <data name="SensorsManager_ActiveWindowSensorDescription" xml:space="preserve">
     <value>Fournit le titre de la fenêtre active actuelle.</value>
   </data>
   <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
-    <value>Fournit des informations sur divers aspects de l&apos;audio de votre appareil :
+    <value>Fournit des informations sur divers aspects de l'audio de votre appareil :
 
 Niveau de volume maximal actuel (peut être utilisé comme une simple valeur ‘quelque chose joue’).
 
 Périphérique audio par défaut : nom, état et volume.
 
-Résumé de vos sessions audio : nom de l&apos;application, état muet, volume et volume maximal actuel.</value>
+Résumé de vos sessions audio : nom de l'application, état muet, volume et volume maximal actuel.</value>
   </data>
   <data name="SensorsManager_BatterySensorsDescription" xml:space="preserve">
-    <value>Fournit à un capteur l&apos;état de charge actuel, le nombre estimé de minutes sur une charge complète, la charge restante en pourcentage, la charge restante en minutes et l&apos;état du branchement au courant.</value>
+    <value>Fournit à un capteur l'état de charge actuel, le nombre estimé de minutes sur une charge complète, la charge restante en pourcentage, la charge restante en minutes et l'état du branchement au courant.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="SensorsManager_CpuLoadSensorDescription" xml:space="preserve">
     <value>Fournit la charge actuelle du premier processeur sous forme de pourcentage.</value>
   </data>
   <data name="SensorsManager_CurrentClockSpeedSensorDescription" xml:space="preserve">
-    <value>Fournit la vitesse d&apos;horloge actuelle du premier processeur.</value>
+    <value>Fournit la vitesse d'horloge actuelle du premier processeur.</value>
   </data>
   <data name="SensorsManager_CurrentVolumeSensorDescription" xml:space="preserve">
     <value>Fournit le niveau de volume actuel sous forme de pourcentage.
@@ -2080,7 +2081,7 @@ Résumé de vos sessions audio : nom de l&apos;application, état muet, volume e
 Indique le volume de votre appareil par défaut.</value>
   </data>
   <data name="SensorsManager_DisplaySensorsDescription" xml:space="preserve">
-    <value>Créé un capteur avec le nombre d&apos;écrans, le nom de l&apos;écran principal et pour chaque écran, son nom, sa résolution et ses points par pixel.</value>
+    <value>Créé un capteur avec le nombre d'écrans, le nom de l'écran principal et pour chaque écran, son nom, sa résolution et ses points par pixel.</value>
   </data>
   <data name="SensorsManager_DummySensorDescription" xml:space="preserve">
     <value>Capteur factice à des fins de test, envoie une valeur entière aléatoire entre 0 et 100.</value>
@@ -2092,12 +2093,12 @@ Indique le volume de votre appareil par défaut.</value>
     <value>Fournit la température actuelle du premier GPU.</value>
   </data>
   <data name="SensorsManager_LastActiveSensorDescription" xml:space="preserve">
-    <value>Fournit la date et l&apos;heure de la dernière utilisation d&apos;un périphérique par l&apos;utilisateur.</value>
+    <value>Fournit la date et l'heure de la dernière utilisation d'un périphérique par l'utilisateur.</value>
   </data>
   <data name="SensorsManager_LastBootSensorDescription" xml:space="preserve">
     <value>Provides a datetime value containing the last moment the system (re)booted.
 
-Important: Windows&apos; FastBoot option can throw this value off, because that&apos;s a form of hibernation. You can disable it through Power Options -&gt; &apos;Choose what the power buttons do&apos; -&gt; uncheck &apos;Turn on fast start-up&apos;. It doesn&apos;t make much difference for modern machines with SSDs, but disabling makes sure you get a clean state after rebooting.</value>
+Important: Windows' FastBoot option can throw this value off, because that's a form of hibernation. You can disable it through Power Options -&gt; 'Choose what the power buttons do' -&gt; uncheck 'Turn on fast start-up'. It doesn't make much difference for modern machines with SSDs, but disabling makes sure you get a clean state after rebooting.</value>
   </data>
   <data name="SensorsManager_LastSystemStateChangeSensorDescription" xml:space="preserve">
     <value>Provides the last system state change:
@@ -2105,7 +2106,7 @@ Important: Windows&apos; FastBoot option can throw this value off, because that&
 ApplicationStarted, Logoff, SystemShutdown, Resume, Suspend, ConsoleConnect, ConsoleDisconnect, RemoteConnect, RemoteDisconnect, SessionLock, SessionLogoff, SessionLogon, SessionRemoteControl and SessionUnlock.</value>
   </data>
   <data name="SensorsManager_LoggedUserSensorDescription" xml:space="preserve">
-    <value>Renvoie le nom de l&apos;utilisateur actuellement connecté.</value>
+    <value>Renvoie le nom de l'utilisateur actuellement connecté.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="SensorsManager_LoggedUsersSensorDescription" xml:space="preserve">
@@ -2120,15 +2121,15 @@ ApplicationStarted, Logoff, SystemShutdown, Resume, Suspend, ConsoleConnect, Con
     <comment>Fuzzy</comment>
   </data>
   <data name="SensorsManager_NamedWindowSensorDescription" xml:space="preserve">
-    <value>Fournit une valeur ON/OFF selon si la fenêtre est actuellement ouverte (elle n&apos;a pas besoin d&apos;être active).</value>
+    <value>Fournit une valeur ON/OFF selon si la fenêtre est actuellement ouverte (elle n'a pas besoin d'être active).</value>
   </data>
   <data name="SensorsManager_NetworkSensorsDescription" xml:space="preserve">
     <value>Fournit des informations sur la carte, la configuration, les statistiques de transfert et les adresses (ip, mac, dhcp, dns) de la ou des cartes réseau sélectionnées.
 
-Il s&apos;agit d&apos;un capteur multi-valeur.</value>
+Il s'agit d'un capteur multi-valeur.</value>
   </data>
   <data name="SensorsManager_PerformanceCounterSensorDescription" xml:space="preserve">
-    <value>Fournit les valeurs d&apos;un compteur de performance.
+    <value>Fournit les valeurs d'un compteur de performance.
 
 Par exemple, le capteur de charge du processeur utilise ces valeurs :
 
@@ -2136,16 +2137,16 @@ Catégorie : Processeur
 Compteur : % du temps processeur
 Instance : _Total
 
-Vous pouvez explorer les compteurs via l&apos;outil &apos;perfmon.exe&apos; de Windows.</value>
+Vous pouvez explorer les compteurs via l'outil 'perfmon.exe' de Windows.</value>
   </data>
   <data name="SensorsManager_ProcessActiveSensorDescription" xml:space="preserve">
-    <value>Fournit le nombre d&apos;instances actives du processus.</value>
+    <value>Fournit le nombre d'instances actives du processus.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
     <value>Returns the state of the provided service: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending or Paused.
 
-Make sure to provide the &apos;Service name&apos;, not the &apos;Display name&apos;.</value>
+Make sure to provide the 'Service name', not the 'Display name'.</value>
   </data>
   <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
     <value>Provides the current session state:
@@ -2155,7 +2156,7 @@ Locked, Unlocked or Unknown.
 Use a LastSystemStateChangeSensor to monitor session state changes.</value>
   </data>
   <data name="SensorsManager_StorageSensorsDescription" xml:space="preserve">
-    <value>Fournit les libellés, la taille totale (MB), l&apos;espace disponible (MB), l&apos;espace utilisé (MB) et le système de fichiers de tous les disques non amovibles présents.</value>
+    <value>Fournit les libellés, la taille totale (MB), l'espace disponible (MB), l'espace utilisé (MB) et le système de fichiers de tous les disques non amovibles présents.</value>
   </data>
   <data name="SensorsManager_UserNotificationStateSensorDescription" xml:space="preserve">
     <value>Provides the current user state:
@@ -2167,12 +2168,12 @@ Can for instance be used to determine whether to send notifications or TTS messa
   <data name="SensorsManager_WebcamActiveSensorDescription" xml:space="preserve">
     <value>Provides a bool value based on whether the webcam is currently being used.
 
-Note: if used in the satellite service, it won&apos;t detect userspace applications.</value>
+Note: if used in the satellite service, it won't detect userspace applications.</value>
   </data>
   <data name="SensorsManager_WindowsUpdatesSensorsDescription" xml:space="preserve">
-    <value>Provides a sensor with the amount of pending driver updates, a sensor with the amount of pending software updates, a sensor containing all pending driver updates information (title, kb article id&apos;s, hidden, type and categories) and a sensor containing the same for pending software updates.
+    <value>Provides a sensor with the amount of pending driver updates, a sensor with the amount of pending software updates, a sensor containing all pending driver updates information (title, kb article id's, hidden, type and categories) and a sensor containing the same for pending software updates.
 
-This is a costly request, so the recommended interval is 15 minutes (900 seconds). But it&apos;s capped at 10 minutes, if you provide a lower value, you&apos;ll get the last known list.</value>
+This is a costly request, so the recommended interval is 15 minutes (900 seconds). But it's capped at 10 minutes, if you provide a lower value, you'll get the last known list.</value>
   </data>
   <data name="SensorsManager_WmiQuerySensorDescription" xml:space="preserve">
     <value>Fournit le résultat de la requête WMI.</value>
@@ -2183,12 +2184,12 @@ This is a costly request, so the recommended interval is 15 minutes (900 seconds
 {0}</value>
   </data>
   <data name="SettingsManager_StoreInitialSettings_MessageBox1" xml:space="preserve">
-    <value>Erreur lors de l&apos;enregistrement des paramètres initiaux :
+    <value>Erreur lors de l'enregistrement des paramètres initiaux :
 
 {0}</value>
   </data>
   <data name="SettingsManager_StoreAppSettings_MessageBox1" xml:space="preserve">
-    <value>Erreur lors de l&apos;enregistrement des paramètres :
+    <value>Erreur lors de l'enregistrement des paramètres :
 
 {0}</value>
   </data>
@@ -2198,7 +2199,7 @@ This is a costly request, so the recommended interval is 15 minutes (900 seconds
 {0}</value>
   </data>
   <data name="StoredCommands_Store_MessageBox1" xml:space="preserve">
-    <value>Erreur lors de l&apos;enregistrement des commandes :
+    <value>Erreur lors de l'enregistrement des commandes :
 
 {0}</value>
   </data>
@@ -2208,7 +2209,7 @@ This is a costly request, so the recommended interval is 15 minutes (900 seconds
 {0}</value>
   </data>
   <data name="StoredQuickActions_Store_MessageBox1" xml:space="preserve">
-    <value>Erreur lors de l&apos;enregistrement des actions rapides :
+    <value>Erreur lors de l'enregistrement des actions rapides :
 
 {0}</value>
   </data>
@@ -2218,7 +2219,7 @@ This is a costly request, so the recommended interval is 15 minutes (900 seconds
 {0}</value>
   </data>
   <data name="StoredSensors_Store_MessageBox1" xml:space="preserve">
-    <value>Erreur lors de l&apos;enregistrement des capteurs :
+    <value>Erreur lors de l'enregistrement des capteurs :
 
 {0}</value>
   </data>
@@ -2232,7 +2233,7 @@ This is a costly request, so the recommended interval is 15 minutes (900 seconds
     <value>Occupé, Patientez ..</value>
   </data>
   <data name="ConfigGeneral_LblInterfaceLangauge" xml:space="preserve">
-    <value>Langage de l&apos;interface</value>
+    <value>Langage de l'interface</value>
   </data>
   <data name="About_LblOr" xml:space="preserve">
     <value>ou</value>
@@ -2241,7 +2242,7 @@ This is a costly request, so the recommended interval is 15 minutes (900 seconds
     <value>Terminer</value>
   </data>
   <data name="OnboardingWelcome_LblInterfaceLangauge" xml:space="preserve">
-    <value>Langage de l&apos;interface</value>
+    <value>Langage de l'interface</value>
   </data>
   <data name="ServiceMqtt_SetMqttStatus_ConfigError" xml:space="preserve">
     <value>Configuration manquante</value>
@@ -2394,7 +2395,7 @@ This is a costly request, so the recommended interval is 15 minutes (900 seconds
     <value>Charge CPU</value>
   </data>
   <data name="SensorType_CurrentClockSpeedSensor" xml:space="preserve">
-    <value>Vitesse d&apos;horloge</value>
+    <value>Vitesse d'horloge</value>
   </data>
   <data name="SensorType_CurrentVolumeSensor" xml:space="preserve">
     <value>Volume actuel</value>
@@ -2418,7 +2419,7 @@ This is a costly request, so the recommended interval is 15 minutes (900 seconds
     <value>Dernier démarrage</value>
   </data>
   <data name="SensorType_LastSystemStateChangeSensor" xml:space="preserve">
-    <value>Dernier changement d&apos;état du système</value>
+    <value>Dernier changement d'état du système</value>
   </data>
   <data name="SensorType_LoggedUserSensor" xml:space="preserve">
     <value>Utilisateur connecté</value>
@@ -2577,7 +2578,7 @@ This is a costly request, so the recommended interval is 15 minutes (900 seconds
     <value>Carte du reseau</value>
   </data>
   <data name="SensorsMod_TestPerformanceCounter_MessageBox1" xml:space="preserve">
-    <value>Entrez d&apos;abord une catégorie et un compteur.</value>
+    <value>Entrez d'abord une catégorie et un compteur.</value>
   </data>
   <data name="SensorsMod_TestPerformanceCounter_MessageBox2" xml:space="preserve">
     <value>Test exécuté avec succès, valeur du résultat :
@@ -2585,14 +2586,14 @@ This is a costly request, so the recommended interval is 15 minutes (900 seconds
 {0}</value>
   </data>
   <data name="SensorsMod_TestPerformanceCounter_MessageBox3" xml:space="preserve">
-    <value>Le test n&apos;a pas réussi a s&apos;exécuter :
+    <value>Le test n'a pas réussi a s'exécuter :
 
 {0}
 
 Voulez-vous ouvrir le dossier des journaux ?</value>
   </data>
   <data name="SensorsMod_TestWmi_MessageBox1" xml:space="preserve">
-    <value>Saisissez d&apos;abord une requête WMI.</value>
+    <value>Saisissez d'abord une requête WMI.</value>
   </data>
   <data name="SensorsMod_TestWmi_MessageBox2" xml:space="preserve">
     <value>Requête exécutée avec succès, valeur du résultat :
@@ -2600,7 +2601,7 @@ Voulez-vous ouvrir le dossier des journaux ?</value>
 {0}</value>
   </data>
   <data name="SensorsMod_TestWmi_MessageBox3" xml:space="preserve">
-    <value>La requête n&apos;a pas réussi a s&apos;exécuter :
+    <value>La requête n'a pas réussi a s'exécuter :
 
 {0}
 
@@ -2615,7 +2616,7 @@ The scope you entered:
 
 {0}
 
-Tip: make sure you haven&apos;t switched the scope and query fields around.
+Tip: make sure you haven't switched the scope and query fields around.
 
 Do you still want to use the current values?</value>
   </data>
@@ -2623,15 +2624,15 @@ Do you still want to use the current values?</value>
     <value>Application démarrée</value>
   </data>
   <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
-    <value>Vous pouvez utiliser le Service Windows pour faire fonctionner les capteurs et commandes sans avoir à vous connecter. Tous ne sont pas disponibles, par exemple la commande &apos;LaunchUrl&apos; ne peut pas être lancée par le service.</value>
+    <value>Vous pouvez utiliser le Service Windows pour faire fonctionner les capteurs et commandes sans avoir à vous connecter. Tous ne sont pas disponibles, par exemple la commande 'LaunchUrl' ne peut pas être lancée par le service.</value>
   </data>
   <data name="SensorsConfig_ClmValue" xml:space="preserve">
     <value>Dernière valeur connue</value>
   </data>
   <data name="LocalApiManager_Initialize_MessageBox1" xml:space="preserve">
-    <value>Erreur lors de la tentative de connexion de l&apos;API au port {0}.
+    <value>Erreur lors de la tentative de connexion de l'API au port {0}.
 
-Assurez vous qu&apos;aucune autre instance de HASS.Agent n&apos;est en cours d&apos;exécution et que le port est disponible et enregistré.</value>
+Assurez vous qu'aucune autre instance de HASS.Agent n'est en cours d'exécution et que le port est disponible et enregistré.</value>
   </data>
   <data name="CommandType_SendWindowToFrontCommand" xml:space="preserve">
     <value>Afficher la fenêtre au premier plan</value>
@@ -2640,26 +2641,26 @@ Assurez vous qu&apos;aucune autre instance de HASS.Agent n&apos;est en cours d&a
     <value>WebView</value>
   </data>
   <data name="CommandsManager_WebViewCommandDescription" xml:space="preserve">
-    <value>Affiche une fenêtre avec l&apos;URL fournie.
+    <value>Affiche une fenêtre avec l'URL fournie.
 
-Cela diffère de la commande &apos;LaunchUrl&apos; en ce qu&apos;elle ne charge pas un navigateur à part entière, juste l&apos;URL fournie dans sa propre fenêtre.
+Cela diffère de la commande 'LaunchUrl' en ce qu'elle ne charge pas un navigateur à part entière, juste l'URL fournie dans sa propre fenêtre.
 
-Vous pouvez l&apos;utiliser par exemple pour afficher rapidement le tableau de bord de Home Assistant.
+Vous pouvez l'utiliser par exemple pour afficher rapidement le tableau de bord de Home Assistant.
 
-Par défaut, il stocke les cookies indéfiniment, vous n&apos;avez donc qu&apos;à vous connecter une seule fois.</value>
+Par défaut, il stocke les cookies indéfiniment, vous n'avez donc qu'à vous connecter une seule fois.</value>
   </data>
   <data name="HassDomain_HASSAgentCommands" xml:space="preserve">
     <value>Commandes HASS.Agent</value>
   </data>
   <data name="CommandsManager_CommandsManager_SendWindowToFrontCommandDescription" xml:space="preserve">
-    <value>Recherche le processus spécifié et essaie d&apos;afficher sa fenêtre principale au premier plan.
+    <value>Recherche le processus spécifié et essaie d'afficher sa fenêtre principale au premier plan.
 
-Si l&apos;application est réduite, elle sera restaurée.
+Si l'application est réduite, elle sera restaurée.
 
-Exemple : si vous voulez envoyer VLC au premier plan, utilisez &apos;vlc&apos;.</value>
+Exemple : si vous voulez envoyer VLC au premier plan, utilisez 'vlc'.</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
-    <value>Si vous ne configurez pas la commande, vous ne pouvez utiliser cette entité qu&apos;avec une valeur &apos;action&apos; via Home Assistant et elle s&apos;affichera en utilisant les paramètres par défaut. La faire fonctionner tel quel ne fera rien.
+    <value>Si vous ne configurez pas la commande, vous ne pouvez utiliser cette entité qu'avec une valeur 'action' via Home Assistant et elle s'affichera en utilisant les paramètres par défaut. La faire fonctionner tel quel ne fera rien.
 
 Etes vous sûr de vouloir cela ? </value>
   </data>
@@ -2682,11 +2683,11 @@ Etes vous sûr de vouloir cela ? </value>
     <value>Le cache WebView a été nettoyé !</value>
   </data>
   <data name="Main_CheckDpiScalingFactor_MessageBox1" xml:space="preserve">
-    <value>Il semble que vous utilisiez une mise à l&apos;échelle personnalisée. Il se peut que certaines parties de HASS.Agent ne s&apos;affichent pas comme prévu.
+    <value>Il semble que vous utilisiez une mise à l'échelle personnalisée. Il se peut que certaines parties de HASS.Agent ne s'affichent pas comme prévu.
 
 Veuillez signaler tout aspect inutilisable sur GitHub. Merci!
 
-Remarque : ce message ne s&apos;affiche qu&apos;une seule fois.</value>
+Remarque : ce message ne s'affiche qu'une seule fois.</value>
   </data>
   <data name="WebViewCommandConfig_SetStoredVariables_MessageBox1" xml:space="preserve">
     <value>Impossible de charger les paramètres enregistrés de la commande, réinitialisation par défaut.</value>
@@ -2698,12 +2699,12 @@ Remarque : ce message ne s&apos;affiche qu&apos;une seule fois.</value>
     <value>Lancer la réservation des ports</value>
   </data>
   <data name="ConfigLocalApi_CbLocalApiActive" xml:space="preserve">
-    <value>Activer l&apos;API locale</value>
+    <value>Activer l'API locale</value>
   </data>
   <data name="ConfigLocalApi_LblInfo1" xml:space="preserve">
     <value>HASS.Agent a sa propre API locale, donc Home Assistant peut envoyer des requêtes (par exemple pour envoyer une notification). Vous pouvez le configurer globalement ici, et ensuite vous pouvez configurer les sections qui en dépendent (actuellement les notifications et le lecteur multimédia).
 
-Remarque : ceci n&apos;est pas nécessaire pour que la nouvelle intégration fonctionne. Activez-le et utilisez-le uniquement si vous n&apos;utilisez pas MQTT.</value>
+Remarque : ceci n'est pas nécessaire pour que la nouvelle intégration fonctionne. Activez-le et utilisez-le uniquement si vous n'utilisez pas MQTT.</value>
   </data>
   <data name="ConfigLocalApi_LblInfo2" xml:space="preserve">
     <value>Pour pouvoir écouter les requêtes, HASS.Agents doit avoir son port réservé et ouvert dans votre pare-feu. Vous pouvez utiliser ce bouton pour le faire pour vous.</value>
@@ -2719,10 +2720,10 @@ Remarque : ceci n&apos;est pas nécessaire pour que la nouvelle intégration fon
     <value>jours</value>
   </data>
   <data name="ConfigLocalStorage_LblImageCacheLocation" xml:space="preserve">
-    <value>Emplacement du cache d&apos;images</value>
+    <value>Emplacement du cache d'images</value>
   </data>
   <data name="ConfigLocalStorage_LblKeepAudio" xml:space="preserve">
-    <value>Garder l&apos;audio pendant</value>
+    <value>Garder l'audio pendant</value>
   </data>
   <data name="ConfigLocalStorage_LblKeepImages" xml:space="preserve">
     <value>Garder les images pendant</value>
@@ -2740,31 +2741,31 @@ Remarque : ceci n&apos;est pas nécessaire pour que la nouvelle intégration fon
     <value>Activer la fonctionnalité lecteur multimédia</value>
   </data>
   <data name="ConfigMediaPlayer_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent peut agir comme un lecteur multimédia pour Home Assistant, vous pourrez donc contrôler tous les médias en cours de lecture et envoyer de la synthèse vocale. L&apos;API locale doit être activée pour que cela fonctionne.</value>
+    <value>HASS.Agent peut agir comme un lecteur multimédia pour Home Assistant, vous pourrez donc contrôler tous les médias en cours de lecture et envoyer de la synthèse vocale. L'API locale doit être activée pour que cela fonctionne.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigMediaPlayer_LblInfo2" xml:space="preserve">
     <value>Si quelque chose ne fonctionne pas, suivez les étapes suivantes:
 
-- Installer l&apos;intégration HASS.Agent-MediaPlayer
+- Installer l'intégration HASS.Agent-MediaPlayer
 - Redémarrer Home Assistant
 - Configurer une entité media_player
 - Redémarrer Home Assistant</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigMediaPlayer_LblLocalApiDisabled" xml:space="preserve">
-    <value>L&apos;API locale est désactivée, mais le lecteur multimédia en a besoin pour fonctionner </value>
+    <value>L'API locale est désactivée, mais le lecteur multimédia en a besoin pour fonctionner </value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigMqtt_CbMqttTls" xml:space="preserve">
     <value>TLS</value>
   </data>
   <data name="ConfigNotifications_LblLocalApiDisabled" xml:space="preserve">
-    <value>L&apos;API locale est désactivée, le lecteur multimédia en a besoin pour fonctionner </value>
+    <value>L'API locale est désactivée, le lecteur multimédia en a besoin pour fonctionner </value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigTrayIcon_BtnShowWebViewPreview" xml:space="preserve">
-    <value>Afficher l&apos;aperçu</value>
+    <value>Afficher l'aperçu</value>
   </data>
   <data name="ConfigTrayIcon_CbDefaultMenu" xml:space="preserve">
     <value>Afficher le menu &amp;default</value>
@@ -2776,7 +2777,7 @@ Remarque : ceci n&apos;est pas nécessaire pour que la nouvelle intégration fon
     <value>Garder la page chargée en arrière-plan</value>
   </data>
   <data name="ConfigTrayIcon_LblInfo1" xml:space="preserve">
-    <value>Contrôler la façon dont l&apos;icone de la barre d&apos;état se comporte suite à un clique droit.</value>
+    <value>Contrôler la façon dont l'icone de la barre d'état se comporte suite à un clique droit.</value>
   </data>
   <data name="ConfigTrayIcon_LblInfo2" xml:space="preserve">
     <value>Cela utilise plus de ressource, mais réduit le temps de chargement</value>
@@ -2794,13 +2795,13 @@ Remarque : ceci n&apos;est pas nécessaire pour que la nouvelle intégration fon
     <value>Lecteur Multimédia</value>
   </data>
   <data name="Configuration_TabTrayIcon" xml:space="preserve">
-    <value>Icon de la barre d&apos;état</value>
+    <value>Icon de la barre d'état</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
-    <value>Votre langue de saisie &apos;{0}&apos; est connue pour entrer en conflit avec le raccourci clavier par défaut CTRL-ALT-Q. Veuillez en définir un autre.</value>
+    <value>Votre langue de saisie '{0}' est connue pour entrer en conflit avec le raccourci clavier par défaut CTRL-ALT-Q. Veuillez en définir un autre.</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
-    <value>Your input language &apos;{0}&apos; is unknown, and might collide with the default CTRL-ALT-Q hotkey. Please check to be sure. If it does, consider opening a ticket on GitHub so it can be added to the list.</value>
+    <value>Your input language '{0}' is unknown, and might collide with the default CTRL-ALT-Q hotkey. Please check to be sure. If it does, consider opening a ticket on GitHub so it can be added to the list.</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
     <value>Aucune touche trouvée</value>
@@ -2809,7 +2810,7 @@ Remarque : ceci n&apos;est pas nécessaire pour que la nouvelle intégration fon
     <value>Crochets manquants, démarrez et terminez toutes les combinaisons de touche avec [ ]</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg3" xml:space="preserve">
-    <value>Erreur sur une touche, vérifier le journal pour plus d&apos;informations</value>
+    <value>Erreur sur une touche, vérifier le journal pour plus d'informations</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
     <value>Le nombre de crochets ouverts [ ne correspond pas au nombre de crochets fermés ] ! ({0} contre {1})</value>
@@ -2818,7 +2819,7 @@ Remarque : ceci n&apos;est pas nécessaire pour que la nouvelle intégration fon
     <value>Documentation</value>
   </data>
   <data name="Help_LblDocumentationInfo" xml:space="preserve">
-    <value>Documentation et exemples d&apos;utilisation.</value>
+    <value>Documentation et exemples d'utilisation.</value>
   </data>
   <data name="Main_BtnCheckForUpdate" xml:space="preserve">
     <value>Vérifier les mises à jour</value>
@@ -2830,31 +2831,31 @@ Remarque : ceci n&apos;est pas nécessaire pour que la nouvelle intégration fon
     <value>Gérer le Service Windows</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo1" xml:space="preserve">
-    <value>Pour utiliser les notifications, vous devez installer et configurer l&apos;intégration HASS.Agent-notifier dans
+    <value>Pour utiliser les notifications, vous devez installer et configurer l'intégration HASS.Agent-notifier dans
 Home Assistant.
 
-C&apos;est très facile avec HACS, mais vous pouvez également l&apos;installer manuellement. Visitez le lien ci-dessous pour plus
+C'est très facile avec HACS, mais vous pouvez également l'installer manuellement. Visitez le lien ci-dessous pour plus
 informations.</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo2" xml:space="preserve">
     <value>Suivez les étapes suivantes :
 
-- Installer l&apos;intégration HASS.Agent-Notifier et/ou HASS.Agent-MediaPlayer
+- Installer l'intégration HASS.Agent-Notifier et/ou HASS.Agent-MediaPlayer
 - Redémarrez Home Assistant
 -Configurer une notification et/ou une entité media_player
 -Redémarrer Home Assistant</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo3" xml:space="preserve">
-    <value>Il en va de même pour le lecteur multimédia. Cette intégration vous permet de contrôler votre appareil en tant qu&apos;entité media_player, de voir ce qui se joue et d&apos;utiliser la synthèse vocale.</value>
+    <value>Il en va de même pour le lecteur multimédia. Cette intégration vous permet de contrôler votre appareil en tant qu'entité media_player, de voir ce qui se joue et d'utiliser la synthèse vocale.</value>
   </data>
   <data name="OnboardingIntegrations_LblMediaPlayerIntegration" xml:space="preserve">
     <value>Page GitHub HASS.Agent-MediaPlayer</value>
   </data>
   <data name="OnboardingIntegrations_LblNotifierIntegration" xml:space="preserve">
-    <value>Github de l&apos;integration HASS.Agent</value>
+    <value>Github de l'integration HASS.Agent</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableLocalApi" xml:space="preserve">
-    <value>Oui, activez l&apos;API locale sur le port</value>
+    <value>Oui, activez l'API locale sur le port</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableMediaPlayer" xml:space="preserve">
     <value>Activer le lecteur multimédia et la synthèse vocale</value>
@@ -2865,13 +2866,13 @@ informations.</value>
   <data name="OnboardingLocalApi_LblInfo1" xml:space="preserve">
     <value>HASS.Agent a sa propre API interne, donc Home Assistant peut envoyer des requêtes (comme des notifications ou une synthèse vocale).
 
-Voulez-vous l&apos;activer ?</value>
+Voulez-vous l'activer ?</value>
   </data>
   <data name="OnboardingLocalApi_LblInfo2" xml:space="preserve">
-    <value>Vous pouvez choisir les modules que vous souhaitez activer. Ils nécessitent des intégrations HA, mais ne vous inquiétez pas, la page suivante vous donnera plus d&apos;informations sur la façon de les configurer.</value>
+    <value>Vous pouvez choisir les modules que vous souhaitez activer. Ils nécessitent des intégrations HA, mais ne vous inquiétez pas, la page suivante vous donnera plus d'informations sur la façon de les configurer.</value>
   </data>
   <data name="OnboardingLocalApi_LblTip1" xml:space="preserve">
-    <value>Remarque : 5115 est le port par défaut, ne le modifiez que si vous l&apos;avez modifié dans Home Assistant.</value>
+    <value>Remarque : 5115 est le port par défaut, ne le modifiez que si vous l'avez modifié dans Home Assistant.</value>
   </data>
   <data name="OnboardingMqtt_CbMqttTls" xml:space="preserve">
     <value>TLS</value>
@@ -2896,7 +2897,7 @@ Do you want to use that version?</value>
     <value>Sauvegarder</value>
   </data>
   <data name="WebViewCommandConfig_CbCenterScreen" xml:space="preserve">
-    <value>Toujours afficher au centre de l&apos;écran</value>
+    <value>Toujours afficher au centre de l'écran</value>
   </data>
   <data name="WebViewCommandConfig_CbShowTitleBar" xml:space="preserve">
     <value>Afficher la barre de titre de la fenêtre</value>
@@ -2905,7 +2906,7 @@ Do you want to use that version?</value>
     <value>Définir la fenêtre comme toujours en haut</value>
   </data>
   <data name="WebViewCommandConfig_LblInfo1" xml:space="preserve">
-    <value>Déplacez et redimensionnez cette fenêtre pour définir la taille et l&apos;emplacement de l&apos;affichage WebView.</value>
+    <value>Déplacez et redimensionnez cette fenêtre pour définir la taille et l'emplacement de l'affichage WebView.</value>
   </data>
   <data name="WebViewCommandConfig_LblLocation" xml:space="preserve">
     <value>Localisation</value>
@@ -2914,7 +2915,7 @@ Do you want to use that version?</value>
     <value>Taille</value>
   </data>
   <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
-    <value>Conseil : Appuyez sur &quot;ESC&quot; pour fermer une vue WebView</value>
+    <value>Conseil : Appuyez sur "ESC" pour fermer une vue WebView</value>
   </data>
   <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
     <value>URL</value>
@@ -2926,21 +2927,21 @@ Do you want to use that version?</value>
     <value>WebView</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox9" xml:space="preserve">
-    <value>Le code de touche que vous avez entré n&apos;est pas valide !
+    <value>Le code de touche que vous avez entré n'est pas valide !
 
 Assurez vous que le champ du code de touche est sélectionné et appuyez sur la touche que vous souhaitez simuler, le code de touche devrait alors être rempli pour vous.</value>
   </data>
   <data name="ConfigGeneral_CbEnableDeviceNameSanitation" xml:space="preserve">
-    <value>Activer le nettoyage du nom de l&apos;appareil</value>
+    <value>Activer le nettoyage du nom de l'appareil</value>
   </data>
   <data name="ConfigGeneral_CbEnableStateNotifications" xml:space="preserve">
-    <value>Activer les notifications d&apos;état</value>
+    <value>Activer les notifications d'état</value>
   </data>
   <data name="ConfigGeneral_LblInfo5" xml:space="preserve">
-    <value>HASS.Agent va nettoyer le nom de votre appareil pour s&apos;assurer que HA l&apos;acceptera, vous pouvez annuler cette règle ci-dessous si vous êtes sûr que votre nom sera accepté tel quel.</value>
+    <value>HASS.Agent va nettoyer le nom de votre appareil pour s'assurer que HA l'acceptera, vous pouvez annuler cette règle ci-dessous si vous êtes sûr que votre nom sera accepté tel quel.</value>
   </data>
   <data name="ConfigGeneral_LblInfo6" xml:space="preserve">
-    <value>HASS.Agent envoie des notifications lorsque l&apos;état d&apos;un module change, vous pouvez définir si vous souhaitez ou non recevoir ces notifications ci-dessous.</value>
+    <value>HASS.Agent envoie des notifications lorsque l'état d'un module change, vous pouvez définir si vous souhaitez ou non recevoir ces notifications ci-dessous.</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox6" xml:space="preserve">
     <value>Vous avez changé le nom de votre appareil.
@@ -3009,7 +3010,7 @@ Remarque : vous avez désactivé le nettoyage du nom, assurez vous donc que le n
     <value>Met tous les moniteurs en mode veille.</value>
   </data>
   <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
-    <value>Essaie de réveiller tous les écrans en simulant une pression sur la touche &quot;flèche vers le haut&quot;.</value>
+    <value>Essaie de réveiller tous les écrans en simulant une pression sur la touche "flèche vers le haut".</value>
   </data>
   <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
     <value>Régler le volume du périphérique audio par défaut actuel au niveau spécifié.</value>
@@ -3021,7 +3022,7 @@ Remarque : vous avez désactivé le nettoyage du nom, assurez vous donc que le n
     <value>Commande</value>
   </data>
   <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
-    <value>Si vous ne saisissez pas de valeur de volume, vous ne pouvez utiliser cette entité qu&apos;avec une commande &quot;action&quot; via Home Assistant. Le faire fonctionner tel quel ne fera rien.
+    <value>Si vous ne saisissez pas de valeur de volume, vous ne pouvez utiliser cette entité qu'avec une commande "action" via Home Assistant. Le faire fonctionner tel quel ne fera rien.
 
 Êtes-vous sûr de vouloir cela ?</value>
   </data>
@@ -3033,21 +3034,21 @@ Remarque : vous avez désactivé le nettoyage du nom, assurez vous donc que le n
 Voulez-vous utiliser cette version ?</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox5" xml:space="preserve">
-    <value>Votre jeton d&apos;API n&apos;a pas l&apos;air correct. Assurez vous d&apos;avoir sélectionné le jeton entier (n&apos;utilisez pas CTRL+A ou double-clic).
+    <value>Votre jeton d'API n'a pas l'air correct. Assurez vous d'avoir sélectionné le jeton entier (n'utilisez pas CTRL+A ou double-clic).
 Il doit contenir trois parties (séparées par deux points).
 
-Etes-vous sûr de vouloir l&apos;utiliser comme ça ?</value>
+Etes-vous sûr de vouloir l'utiliser comme ça ?</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox6" xml:space="preserve">
-    <value>Votre URI ne semble pas correct. Cela devrait ressembler à quelque chose comme &apos;http://homeassistant.local:8123&apos; ou &apos;http://192.168.0.1:8123&apos;.
+    <value>Votre URI ne semble pas correct. Cela devrait ressembler à quelque chose comme 'http://homeassistant.local:8123' ou 'http://192.168.0.1:8123'.
 
-Etes-vous sûr de vouloir l&apos;utiliser comme ça ?</value>
+Etes-vous sûr de vouloir l'utiliser comme ça ?</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_Testing" xml:space="preserve">
     <value>test ...</value>
   </data>
   <data name="ConfigMediaPlayer_LblConnectivityDisabled" xml:space="preserve">
-    <value>L&apos;API locale et MQTT sont tous deux désactivés, l&apos;intégration a besoin d&apos;au moins l&apos;un des deux pour fonctionner.</value>
+    <value>L'API locale et MQTT sont tous deux désactivés, l'intégration a besoin d'au moins l'un des deux pour fonctionner.</value>
   </data>
   <data name="ConfigMqtt_CbEnableMqtt" xml:space="preserve">
     <value>Activer MQTT</value>
@@ -3056,43 +3057,43 @@ Etes-vous sûr de vouloir l&apos;utiliser comme ça ?</value>
     <value>Sans MQTT, Les commandes et capteurs ne fonctionneront pas !</value>
   </data>
   <data name="ConfigNotifications_LblConnectivityDisabled" xml:space="preserve">
-    <value>L&apos;API locale et MQTT sont tous deux désactivés, l&apos;intégration a besoin d&apos;au moins l&apos;un des deux pour fonctionner.</value>
+    <value>L'API locale et MQTT sont tous deux désactivés, l'intégration a besoin d'au moins l'un des deux pour fonctionner.</value>
   </data>
   <data name="ConfigService_BtnManageService" xml:space="preserve">
     <value>Gérer le service</value>
   </data>
   <data name="ConfigService_BtnManageService_MessageBox1" xml:space="preserve">
-    <value>Le service est actuellement à l&apos;arrêt, vous ne pourrez donc pas le configurer.
+    <value>Le service est actuellement à l'arrêt, vous ne pourrez donc pas le configurer.
 
-Assurez vous d&apos;abord qu&apos;il soit opérationnel.</value>
+Assurez vous d'abord qu'il soit opérationnel.</value>
   </data>
   <data name="ConfigService_LblInfo5" xml:space="preserve">
-    <value>Si vous souhaitez gérer le service (ajouter des commandes et capteurs, modifier les paramètres), vous pouvez le faire ici ou en utilisant le bouton &quot;Service Windows&quot; de la fenêtre principale.</value>
+    <value>Si vous souhaitez gérer le service (ajouter des commandes et capteurs, modifier les paramètres), vous pouvez le faire ici ou en utilisant le bouton "Service Windows" de la fenêtre principale.</value>
   </data>
   <data name="ConfigTrayIcon_CbWebViewShowMenuOnLeftClick" xml:space="preserve">
     <value>Afficher le menu par défaut en cliquant avec le bouton gauche de la souris</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox1" xml:space="preserve">
-    <value>Votre jeton d&apos;API Home Assistant ne semble pas correct. Assurez-vous d&apos;avoir sélectionné le jeton entier (n&apos;utilisez pas CTRL+A ou double-clic).
+    <value>Votre jeton d'API Home Assistant ne semble pas correct. Assurez-vous d'avoir sélectionné le jeton entier (n'utilisez pas CTRL+A ou double-clic).
 Il doit contenir trois parties (séparées par deux points).
 
-Etes-vous sûr de vouloir l&apos;utiliser comme ça ?</value>
+Etes-vous sûr de vouloir l'utiliser comme ça ?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
-    <value>L&apos;URI de votre assistant domestique semble incorrect. Cela devrait ressembler à quelque chose comme &apos;http://homeassistant.local:8123&apos; ou &apos;https://192.168.0.1:8123&apos;.
+    <value>L'URI de votre assistant domestique semble incorrect. Cela devrait ressembler à quelque chose comme 'http://homeassistant.local:8123' ou 'https://192.168.0.1:8123'.
 
-Etes-vous sûr de vouloir l&apos;utiliser comme ça ?</value>
+Etes-vous sûr de vouloir l'utiliser comme ça ?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
-    <value>L&apos;URI de votre broker MQTT ne semble pas correct. Il devrait ressembler à quelque chose comme &apos;homeassistant.local&apos; ou &apos;192.168.0.1&apos;.
+    <value>L'URI de votre broker MQTT ne semble pas correct. Il devrait ressembler à quelque chose comme 'homeassistant.local' ou '192.168.0.1'.
 
-Etes-vous sûr de vouloir l&apos;utiliser comme ça ?</value>
+Etes-vous sûr de vouloir l'utiliser comme ça ?</value>
   </data>
   <data name="Donate_BtnClose" xml:space="preserve">
     <value>Fermer</value>
   </data>
   <data name="Donate_CbHideDonateButton" xml:space="preserve">
-    <value>J&apos;ai déjà fait un don, cachez le bouton dans la fenêtre principale.</value>
+    <value>J'ai déjà fait un don, cachez le bouton dans la fenêtre principale.</value>
   </data>
   <data name="Donate_LblInfo" xml:space="preserve">
     <value>HASS.Agent is completely free, and will always stay that way without restrictions!
@@ -3111,21 +3112,21 @@ Like most developers, I run on caffeïne - so if you can spare it, a cup of coff
     <value>Vérifier les mises à jour</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox5" xml:space="preserve">
-    <value>Votre jeton d&apos;API ne semble pas correct. Assurez vous d&apos;avoir sélectionné le jeton entier (n&apos;utilisez pas CTRL+A ou double-clic).
+    <value>Votre jeton d'API ne semble pas correct. Assurez vous d'avoir sélectionné le jeton entier (n'utilisez pas CTRL+A ou double-clic).
 Il doit contenir trois parties (séparées par deux points).
 
-Etes-vous sûr de vouloir l&apos;utiliser comme ça ?</value>
+Etes-vous sûr de vouloir l'utiliser comme ça ?</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox6" xml:space="preserve">
-    <value>Votre URI ne semble pas correct. Cela devrait ressembler à quelque chose comme &apos;http://homeassistant.local:8123&apos; ou &apos;http://192.168.0.1:8123&apos;.
+    <value>Votre URI ne semble pas correct. Cela devrait ressembler à quelque chose comme 'http://homeassistant.local:8123' ou 'http://192.168.0.1:8123'.
 
-Etes-vous sûr de vouloir l&apos;utiliser ainsi ?</value>
+Etes-vous sûr de vouloir l'utiliser ainsi ?</value>
   </data>
   <data name="OnboardingDone_LblInfo6" xml:space="preserve">
-    <value>Développer et maintenir cet outil (et tout ce qui l&apos;entoure) prend beaucoup de temps. Comme la plupart des développeurs, je fonctionne à la caféine - donc si vous pouvez vous le permettre, une tasse de café est toujours très appréciée !</value>
+    <value>Développer et maintenir cet outil (et tout ce qui l'entoure) prend beaucoup de temps. Comme la plupart des développeurs, je fonctionne à la caféine - donc si vous pouvez vous le permettre, une tasse de café est toujours très appréciée !</value>
   </data>
   <data name="OnboardingDone_LblTip2" xml:space="preserve">
-    <value>Astuce : d&apos;autres méthodes de dons sont disponibles dans la fenêtre À propos.</value>
+    <value>Astuce : d'autres méthodes de dons sont disponibles dans la fenêtre À propos.</value>
   </data>
   <data name="OnboardingIntegrations_CbEnableMediaPlayer" xml:space="preserve">
     <value>Activer le lecteur multimédia (et le text-to-speech)</value>
@@ -3140,28 +3141,28 @@ Etes-vous sûr de vouloir l&apos;utiliser ainsi ?</value>
     <value>HASS.Agent Post Update</value>
   </data>
   <data name="SensorsManager_BluetoothDevicesSensorDescription" xml:space="preserve">
-    <value>Fournit un capteur avec le nombre d&apos;appareils Bluetooth trouvés.
+    <value>Fournit un capteur avec le nombre d'appareils Bluetooth trouvés.
 
-Les appareils et leur état de connexion sont ajoutés en tant qu&apos;attributs.</value>
+Les appareils et leur état de connexion sont ajoutés en tant qu'attributs.</value>
   </data>
   <data name="SensorsManager_BluetoothLeDevicesSensorDescription" xml:space="preserve">
-    <value>Fournit à des capteurs le nombre d&apos;appareils Bluetooth LE trouvés.
+    <value>Fournit à des capteurs le nombre d'appareils Bluetooth LE trouvés.
 
-Les appareils et leur état de connexion sont ajoutés en tant qu&apos;attributs.
+Les appareils et leur état de connexion sont ajoutés en tant qu'attributs.
 
-Affiche uniquement les appareils qui ont été vus depuis le dernier rapport, c&apos;est-à-dire que lorsque le capteur publie, la liste s&apos;efface.</value>
+Affiche uniquement les appareils qui ont été vus depuis le dernier rapport, c'est-à-dire que lorsque le capteur publie, la liste s'efface.</value>
   </data>
   <data name="SensorsManager_GeoLocationSensorDescription" xml:space="preserve">
     <value>Renvoie votre latitude, longitude et altitude actuelles sous forme de valeurs séparées par des virgules.
 
 Assurez-vous que les services de localisation de Windows sont activés !
 
-Selon votre version de Windows, cela peut être trouvé dans le nouveau panneau de configuration -&gt; &apos;confidentialité et sécurité&apos; -&gt; &apos;emplacement&apos;.</value>
+Selon votre version de Windows, cela peut être trouvé dans le nouveau panneau de configuration -&gt; 'confidentialité et sécurité' -&gt; 'emplacement'.</value>
   </data>
   <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
-    <value>Provides the name of the process that&apos;s currently using the microphone.
+    <value>Provides the name of the process that's currently using the microphone.
 
-Note: if used in the satellite service, it won&apos;t detect userspace applications.</value>
+Note: if used in the satellite service, it won't detect userspace applications.</value>
   </data>
   <data name="SensorsManager_MonitorPowerStateSensorDescription" xml:space="preserve">
     <value>Provides the last monitor power state change:
@@ -3174,15 +3175,15 @@ Dimmed, PowerOff, PowerOn and Unkown.</value>
 Converts the outcome to text.</value>
   </data>
   <data name="SensorsManager_PrintersSensorsDescription" xml:space="preserve">
-    <value>Fournit des informations sur toutes les imprimantes installées et leurs files d&apos;attente.</value>
+    <value>Fournit des informations sur toutes les imprimantes installées et leurs files d'attente.</value>
   </data>
   <data name="SensorsManager_WebcamProcessSensorDescription" xml:space="preserve">
     <value>Fournit le nom du processus qui utilise actuellement la webcam.
 
-Remarque : s&apos;il est utilisé dans le Service Windows, il ne détectera pas les applications de l&apos;espace utilisateur.</value>
+Remarque : s'il est utilisé dans le Service Windows, il ne détectera pas les applications de l'espace utilisateur.</value>
   </data>
   <data name="SensorsManager_WindowStateSensorDescription" xml:space="preserve">
-    <value>Provides the current state of the process&apos; window:
+    <value>Provides the current state of the process' window:
 
 Hidden, Maximized, Minimized, Normal and Unknown.</value>
   </data>
@@ -3208,7 +3209,7 @@ Voulez-vous utiliser cette version ?</value>
 {0}</value>
   </data>
   <data name="SensorsMod_TestPowershell_MessageBox3" xml:space="preserve">
-    <value>Le test n&apos;a pas pu s&apos;exécuter :
+    <value>Le test n'a pas pu s'exécuter :
 
 {0}
 
@@ -3224,16 +3225,16 @@ Voulez-vous ouvrir le dossier des logs ?</value>
     <value>Erreur fatale, consultez les logs</value>
   </data>
   <data name="ServiceControllerManager_Error_Timeout" xml:space="preserve">
-    <value>Délai d&apos;attente expiré</value>
+    <value>Délai d'attente expiré</value>
   </data>
   <data name="ServiceControllerManager_Error_Unknown" xml:space="preserve">
     <value>Raison inconnue</value>
   </data>
   <data name="ServiceHelper_ChangeStartMode_Error1" xml:space="preserve">
-    <value>Impossible d&apos;ouvrir le gestionnaire de service</value>
+    <value>Impossible d'ouvrir le gestionnaire de service</value>
   </data>
   <data name="ServiceHelper_ChangeStartMode_Error2" xml:space="preserve">
-    <value>Impossible d&apos;ouvrir le service</value>
+    <value>Impossible d'ouvrir le service</value>
   </data>
   <data name="ServiceHelper_ChangeStartMode_Error3" xml:space="preserve">
     <value>Erreur de configuration du mode de démarrage, consultez les logs</value>
@@ -3242,12 +3243,12 @@ Voulez-vous ouvrir le dossier des logs ?</value>
     <value>Erreur lors de la mise en place du mode de démarrage, vérifier les journaux</value>
   </data>
   <data name="WebView_InitializeAsync_MessageBox1" xml:space="preserve">
-    <value>Microsoft&apos;s WebView2 runtime isn&apos;t found on your machine. Usually this is handled by the installer, but you can install it manually.
+    <value>Microsoft's WebView2 runtime isn't found on your machine. Usually this is handled by the installer, but you can install it manually.
 
 Do you want to download the runtime installer?</value>
   </data>
   <data name="WebView_InitializeAsync_MessageBox2" xml:space="preserve">
-    <value>Une erreur s&apos;est produite lors de l&apos;initialisation de WebView ! Veuillez vérifier vos journaux et ouvrir un ticket GitHub pour obtenir de l&apos;aide.</value>
+    <value>Une erreur s'est produite lors de l'initialisation de WebView ! Veuillez vérifier vos journaux et ouvrir un ticket GitHub pour obtenir de l'aide.</value>
   </data>
   <data name="QuickActionsMod_ClmDomain" xml:space="preserve">
     <value>domain</value>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.nl.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.nl.resx
@@ -118,13 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ConfigExternalTools_LblInfo1" xml:space="preserve">
-    <value>Op deze pagina kun je koppelingen met externe programma&apos;s configureren.</value>
+    <value>Op deze pagina kun je koppelingen met externe programma's configureren.</value>
   </data>
   <data name="ConfigExternalTools_LblBrowserName" xml:space="preserve">
     <value>browser naam</value>
   </data>
   <data name="ConfigExternalTools_LblInfo2" xml:space="preserve">
-    <value>‎Standaard start HASS.Agent URL&apos;s met je standaardbrowser. Als je wilt, kun je ook een specifieke browser configureren. Daarnaast kan je de argumenten configureren die worden gebruikt om in privémodus te starten.‎</value>
+    <value>‎Standaard start HASS.Agent URL's met je standaardbrowser. Als je wilt, kun je ook een specifieke browser configureren. Daarnaast kan je de argumenten configureren die worden gebruikt om in privémodus te starten.‎</value>
   </data>
   <data name="ConfigExternalTools_LblBrowserBinary" xml:space="preserve">
     <value>browser binary</value>
@@ -137,7 +137,7 @@
   </data>
   <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
     <value>Je kunt HASS.Agent configureren om een eigen uitvoerder te gebruiken, zoals perl of python.
-Gebruik het &apos;eigen uitvoerder&apos; commando om &apos;m te starten.</value>
+Gebruik het 'eigen uitvoerder' commando om 'm te starten.</value>
   </data>
   <data name="ConfigExternalTools_LblCustomExecutorName" xml:space="preserve">
     <value>eigen uitvoerder naam</value>
@@ -149,7 +149,7 @@ Gebruik het &apos;eigen uitvoerder&apos; commando om &apos;m te starten.</value>
     <value>&amp;test</value>
   </data>
   <data name="ConfigGeneral_LblInfo4" xml:space="preserve">
-    <value>HASS.Agent wacht even voordat je een bericht krijgt over een verbroken verbinding met MQTT of HA&apos;s API.
+    <value>HASS.Agent wacht even voordat je een bericht krijgt over een verbroken verbinding met MQTT of HA's API.
 Je kunt het aantal seconden hier instellen.</value>
   </data>
   <data name="ConfigGeneral_LblDisconGraceSeconds" xml:space="preserve">
@@ -187,11 +187,11 @@ Je automatiseringen en scripts blijven werken.‎</value>
     <value>&amp;test verbinding</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblInfo1" xml:space="preserve">
-    <value>Om te leren welke entiteiten je geconfigureerd hebt, en om snelle acties te versturen, gebruikt HASS.Agent Home Assistant&apos;s API.
+    <value>Om te leren welke entiteiten je geconfigureerd hebt, en om snelle acties te versturen, gebruikt HASS.Agent Home Assistant's API.
 
-Geef een &apos;long-lived access token&apos; op, en het adres van je Home Assistant installatie.
+Geef een 'long-lived access token' op, en het adres van je Home Assistant installatie.
 
-Je kunt zo&apos;n token krijgen via je profiel pagina. Blader naar onderaan de pagina en klik op &apos;TOKEN AANMAKEN&apos;.</value>
+Je kunt zo'n token krijgen via je profiel pagina. Blader naar onderaan de pagina en klik op 'TOKEN AANMAKEN'.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
@@ -229,7 +229,7 @@ Op deze manier kun je, wat je ook aan het doen bent op je machine, altijd commun
   <data name="ConfigLocalStorage_LblInfo1" xml:space="preserve">
     <value>Sommige objecten, zoals afbeeldingen getoond in notificaties, moeten tijdelijk lokaal opgeslagen worden. Je kunt het aantal dagen dat ze bewaard worden instellen, voordat HASS.Agent ze verwijdert.
 
-Voer &apos;0&apos; in om ze permanent te behouden.</value>
+Voer '0' in om ze permanent te behouden.</value>
   </data>
   <data name="ConfigLogging_LblInfo1" xml:space="preserve">
     <value>Uitgebreide logging biedt uitgebreidere logging, voor het geval dat de standaard logging niet voldoende is. Het is belangrijk te weten dat het inschakelen hiervan ervoor zorgt dat de logbestanden flink groeien, en zou dus alleen gebruikt moeten worden als je vermoedt dat er iets mis is met HASS.Agent of als een ontwikkelaar het vraagt.</value>
@@ -263,7 +263,7 @@ Voer &apos;0&apos; in om ze permanent te behouden.</value>
     <value>(leeglaten bij twijfel)</value>
   </data>
   <data name="ConfigMqtt_LblInfo1" xml:space="preserve">
-    <value>Commando&apos;s en sensoren worden verstuurd via MQTT, net als notificaties en mediaspeler functies als je de nieuwe integratie gebruikt.
+    <value>Commando's en sensoren worden verstuurd via MQTT, net als notificaties en mediaspeler functies als je de nieuwe integratie gebruikt.
 
 Geef hier de inloggegevens van je server op. Als je de HA addon gebruikt, kun je waarschijnlijk de vooringevulde gegevens gebruiken.
 
@@ -324,8 +324,8 @@ Notitie: deze instellingen (behalve de cliënt id) zullen ook toegepast worden o
     <value>cert&amp;ificaat fouten voor afbeeldingen negeren</value>
   </data>
   <data name="ConfigService_LblInfo1" xml:space="preserve">
-    <value>De satelliet service laat je sensoren en commando&apos;s uitvoeren, zelfs wanneer er geen gebruiker ingelogd is.
-Gebruik de &apos;satelliet service&apos; knop in het hoofdscherm om &apos;m te beheren.</value>
+    <value>De satelliet service laat je sensoren en commando's uitvoeren, zelfs wanneer er geen gebruiker ingelogd is.
+Gebruik de 'satelliet service' knop in het hoofdscherm om 'm te beheren.</value>
   </data>
   <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
     <value>service status:</value>
@@ -346,8 +346,8 @@ Gebruik de &apos;satelliet service&apos; knop in het hoofdscherm om &apos;m te b
     <value>se&amp;rvice herinstalleren</value>
   </data>
   <data name="ConfigService_LblInfo2" xml:space="preserve">
-    <value>Als je de service niet configureert, doet hij niks. Je kunt alsnog kiezen om &apos;m helemaal uit te schakelen.
-De installer zal de uitgeschakelde service met rust laten (als je &apos;m verwijdert, zal de installer hem terugzetten).</value>
+    <value>Als je de service niet configureert, doet hij niks. Je kunt alsnog kiezen om 'm helemaal uit te schakelen.
+De installer zal de uitgeschakelde service met rust laten (als je 'm verwijdert, zal de installer hem terugzetten).</value>
   </data>
   <data name="ConfigService_LblInfo3" xml:space="preserve">
     <value>Je kunt proberen om de service opnieuw te installeren als hij niet goed werkt. 
@@ -362,7 +362,7 @@ Je configuratie en entiteiten blijven bewaard.</value>
   <data name="ConfigStartup_LblInfo1" xml:space="preserve">
     <value>HASS.Agent kan starten als je inlogt via het register van je gebruikersprofiel.
 
-Aangezien HASS.Agent gebruiker-gebaseerd is, als je &apos;m voor een andere gebruiker wilt starten, kun je daar de configuratie uitvoeren.</value>
+Aangezien HASS.Agent gebruiker-gebaseerd is, als je 'm voor een andere gebruiker wilt starten, kun je daar de configuratie uitvoeren.</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin" xml:space="preserve">
     <value>start-bij-inlogg&amp;en inschakelen</value>
@@ -392,11 +392,11 @@ Je krijgt een notificatie (eenmalig per update) om je te laten weten dat er een 
   <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
     <value>Het lijkt erop dat dit de eerste keer is dat je HASS.Agent start.
 
-Als je wilt, kunnen we de configuratie doorlopen. Zo niet, klik dan op &apos;sluiten&apos;.</value>
+Als je wilt, kunnen we de configuratie doorlopen. Zo niet, klik dan op 'sluiten'.</value>
   </data>
   <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
     <value>Apparaatnaam wordt gebruikt om je machine te identificeren binnen HA.
-Het wordt ook gebruikt om een voorvoegsel voor te stellen voor je commando&apos;s en sensoren.</value>
+Het wordt ook gebruikt om een voorvoegsel voor te stellen voor je commando's en sensoren.</value>
   </data>
   <data name="OnboardingWelcome_LblDeviceName" xml:space="preserve">
     <value>apparaat&amp;naam</value>
@@ -437,7 +437,7 @@ Wil je deze functionaliteit inschakelen?</value>
   <data name="OnboardingIntegration_LblInfo1" xml:space="preserve">
     <value>Om notificaties te gebruiken, moet je de HASS.Agent-Notifier integratie installeren en configureren in Home Assistant.
 
-Dit is simpel met HACS, maar je kunt &apos;m ook handmatig installeren.
+Dit is simpel met HACS, maar je kunt 'm ook handmatig installeren.
 Bezoek de onderstaande link voor meer informatie.</value>
   </data>
   <data name="OnboardingApi_LblApiToken" xml:space="preserve">
@@ -447,11 +447,11 @@ Bezoek de onderstaande link voor meer informatie.</value>
     <value>server &amp;uri (zou al goed moeten zijn)</value>
   </data>
   <data name="OnboardingApi_LblInfo1" xml:space="preserve">
-    <value>Om te leren welke entiteiten je geconfigureerd hebt, en om snelle acties te versturen, gebruikt HASS.Agent Home Assistant&apos;s API.
+    <value>Om te leren welke entiteiten je geconfigureerd hebt, en om snelle acties te versturen, gebruikt HASS.Agent Home Assistant's API.
 
-Geef een &apos;long-lived access token&apos; op, en het adres van je Home Assistant installatie.
+Geef een 'long-lived access token' op, en het adres van je Home Assistant installatie.
 
-Je kunt zo&apos;n token krijgen via je profiel pagina. Blader naar onderaan de pagina en klik op &apos;TOKEN AANMAKEN&apos;.</value>
+Je kunt zo'n token krijgen via je profiel pagina. Blader naar onderaan de pagina en klik op 'TOKEN AANMAKEN'.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="OnboardingApi_BtnTest" xml:space="preserve">
@@ -473,7 +473,7 @@ Je kunt zo&apos;n token krijgen via je profiel pagina. Blader naar onderaan de p
     <value>ip adres of hostname</value>
   </data>
   <data name="OnboardingMqtt_LblInfo1" xml:space="preserve">
-    <value>Commando&apos;s en sensoren worden via MQTT verstuurd. De notificaties- en mediaspeler integratie gebruikt het ook.
+    <value>Commando's en sensoren worden via MQTT verstuurd. De notificaties- en mediaspeler integratie gebruikt het ook.
 
 Tip: als je de HA addon gebruikt, kan je het vooringevulde adres waarschijnlijk gebruiken - geef alleen nog credenties.</value>
     <comment>Fuzzy</comment>
@@ -555,10 +555,10 @@ Bedankt voor het gebruiken van HASS.Agent, hopelijk heb je er wat aan :-)</value
     <value>nieuwe toevoegen</value>
   </data>
   <data name="ServiceCommands_BtnStore" xml:space="preserve">
-    <value>ver&amp;stuur en activeer commando&apos;s</value>
+    <value>ver&amp;stuur en activeer commando's</value>
   </data>
   <data name="ServiceCommands_LblStored" xml:space="preserve">
-    <value>commando&apos;s opgeslagen!</value>
+    <value>commando's opgeslagen!</value>
   </data>
   <data name="ServiceConnect_BtnRetryAuthId" xml:space="preserve">
     <value>toep&amp;assen</value>
@@ -579,7 +579,7 @@ Bedankt voor het gebruiken van HASS.Agent, hopelijk heb je er wat aan :-)</value
     <value>Configuratie ophalen</value>
   </data>
   <data name="ServiceGeneral_LblInfo1" xml:space="preserve">
-    <value>Deze pagina bevat generieke configuratie opties. Blader door de tabbladen bovenaan voor MQTT instellingen, sensoren en commando&apos;s.</value>
+    <value>Deze pagina bevat generieke configuratie opties. Blader door de tabbladen bovenaan voor MQTT instellingen, sensoren en commando's.</value>
   </data>
   <data name="ServiceGeneral_LblAuthId" xml:space="preserve">
     <value>auth id</value>
@@ -643,7 +643,7 @@ Bedankt voor het gebruiken van HASS.Agent, hopelijk heb je er wat aan :-)</value
     <value>(leeglaten bij twijfel)</value>
   </data>
   <data name="ServiceMqtt_LblInfo1" xml:space="preserve">
-    <value>Commando&apos;s en sensoren worden verstuurd via MQTT. Geef de inloggegevens op voor je server. Als je de HA addon gebruikt, kan je waarschijnlijk het vooringevulde adres gebruiken.</value>
+    <value>Commando's en sensoren worden verstuurd via MQTT. Geef de inloggegevens op voor je server. Als je de HA addon gebruikt, kan je waarschijnlijk het vooringevulde adres gebruiken.</value>
   </data>
   <data name="ServiceMqtt_LblDiscoPrefix" xml:space="preserve">
     <value>discovery voorvoegsel</value>
@@ -781,7 +781,7 @@ Bedankt voor het gebruiken van HASS.Agent, hopelijk heb je er wat aan :-)</value
     <value>nieuwe toevoegen</value>
   </data>
   <data name="CommandsConfig_BtnStore" xml:space="preserve">
-    <value>op&amp;slaan en activeren commando&apos;s</value>
+    <value>op&amp;slaan en activeren commando's</value>
   </data>
   <data name="CommandsConfig_ClmName" xml:space="preserve">
     <value>naam</value>
@@ -796,7 +796,7 @@ Bedankt voor het gebruiken van HASS.Agent, hopelijk heb je er wat aan :-)</value
     <value>actie</value>
   </data>
   <data name="CommandsConfig_Title" xml:space="preserve">
-    <value>Commando&apos;s Config</value>
+    <value>Commando's Config</value>
   </data>
   <data name="CommandsMod_BtnStore" xml:space="preserve">
     <value>commando op&amp;slaan</value>
@@ -811,7 +811,7 @@ Bedankt voor het gebruiken van HASS.Agent, hopelijk heb je er wat aan :-)</value
     <value>omschrijving</value>
   </data>
   <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
-    <value>uitvoe&amp;ren als &apos;verlaagde integriteit&apos;</value>
+    <value>uitvoe&amp;ren als 'verlaagde integriteit'</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
     <value>wat is dit?</value>
@@ -993,7 +993,7 @@ Bedankt voor het gebruiken van HASS.Agent, hopelijk heb je er wat aan :-)</value
     <value>     MQTT     </value>
   </data>
   <data name="ServiceConfig_TabCommands" xml:space="preserve">
-    <value>     Commando&apos;s     </value>
+    <value>     Commando's     </value>
   </data>
   <data name="ServiceConfig_TabSensors" xml:space="preserve">
     <value>     Sensoren     </value>
@@ -1008,10 +1008,10 @@ Bedankt voor het gebruiken van HASS.Agent, hopelijk heb je er wat aan :-)</value
     <value>Een Windows-gebaseerde cliënt voor het Home Assistant platform.</value>
   </data>
   <data name="About_LblInfo3" xml:space="preserve">
-    <value>Deze applicatie is open source en volledig gratis. Bekijk de project-pagina&apos;s van de gebruikte componenten voor hun individuele licenties.</value>
+    <value>Deze applicatie is open source en volledig gratis. Bekijk de project-pagina's van de gebruikte componenten voor hun individuele licenties.</value>
   </data>
   <data name="About_LblInfo4" xml:space="preserve">
-    <value>Een oprechte &apos;bedankt&apos; voor de ontwikkelaars van deze projecten, die zo aardig waren om hun harde werken te delen met de rest van de stervelingen ..</value>
+    <value>Een oprechte 'bedankt' voor de ontwikkelaars van deze projecten, die zo aardig waren om hun harde werken te delen met de rest van de stervelingen ..</value>
   </data>
   <data name="About_LblInfo5" xml:space="preserve">
     <value>En natuurlijk; bedankt Paulus Shoutsen en het hele team van ontwikkelaars dat Home Assistant gebouwd hebben en onderhouden :-)</value>
@@ -1092,7 +1092,7 @@ Bedankt voor het gebruiken van HASS.Agent, hopelijk heb je er wat aan :-)</value
     <value>sluiten</value>
   </data>
   <data name="Help_LblInfo1" xml:space="preserve">
-    <value>Zit je vast tijdens het gebruik van HASS.Agent, heb je hulp nodig bij het integreren van sensoren/commando&apos;s of heb je een top idee voor de volgende versie?
+    <value>Zit je vast tijdens het gebruik van HASS.Agent, heb je hulp nodig bij het integreren van sensoren/commando's of heb je een top idee voor de volgende versie?
 
 Er zijn een paar kanalen waar je ons kunt bereiken:</value>
   </data>
@@ -1136,7 +1136,7 @@ Er zijn een paar kanalen waar je ons kunt bereiken:</value>
     <value>lokale sensoren beheren</value>
   </data>
   <data name="Main_TsCommands" xml:space="preserve">
-    <value>commando&apos;s beheren</value>
+    <value>commando's beheren</value>
   </data>
   <data name="Main_CheckForUpdates" xml:space="preserve">
     <value>controleren op updates</value>
@@ -1186,7 +1186,7 @@ Er zijn een paar kanalen waar je ons kunt bereiken:</value>
     <value>satelliet service:</value>
   </data>
   <data name="Main_LblCommands" xml:space="preserve">
-    <value>commando&apos;s:</value>
+    <value>commando's:</value>
   </data>
   <data name="Main_LblSensors" xml:space="preserve">
     <value>sensoren:</value>
@@ -1233,12 +1233,12 @@ Er zijn een paar kanalen waar je ons kunt bereiken:</value>
   <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
     <value>Een eigen commando uitvoeren.
 
-Deze commando&apos;s draaien zonder speciale privileges. Om met verhoogde privileges uit te voeren, maak een Geplande Taak en gebruik &apos;schtasks /Run /TN &quot;TaskName&quot;&apos; als commando om the taak uit te voeren.
+Deze commando's draaien zonder speciale privileges. Om met verhoogde privileges uit te voeren, maak een Geplande Taak en gebruik 'schtasks /Run /TN "TaskName"' als commando om the taak uit te voeren.
 
-Of schakel &apos;uitvoeren met verlaagde integriteit&apos; in voor een strictere uitvoering.</value>
+Of schakel 'uitvoeren met verlaagde integriteit' in voor een strictere uitvoering.</value>
   </data>
   <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
-    <value>Voert het commando uit via de geconfigureerde eigen executor (in Configuratie -&gt; Externe Programma&apos;s).
+    <value>Voert het commando uit via de geconfigureerde eigen executor (in Configuratie -&gt; Externe Programma's).
 
 Je commando wordt onveranderd toegevoegd als argument, dus je moet je eigen haakjes etc. toevoegen indien nodig.</value>
   </data>
@@ -1248,17 +1248,18 @@ Je commando wordt onveranderd toegevoegd als argument, dus je moet je eigen haak
   <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
     <value>Simuleert een enkele toetsaanslag.
 
-Klik op het &apos;keycode&apos; veld en druk de toets in die je gesimuleerd wilt hebben. De corresponderende keycode wordt voor je ingevuld.
+Klik op het tekstvak 'sleutelcode' en druk op de sleutel die u wilt simuleren. De bijbehorende sleutelcode wordt voor u ingevoerd.
+Gebruik voor de TAB-sleutel LCTRL+TAB.
 
-Als je meer toetsen nodig hebt en/of extra opties zoals CTRL, gebruik dan de MeerdereToetsen commando.</value>
+Als u meer sleutels en/of modifiers zoals CTRL nodig heeft, gebruikt u de opdracht MultipleKeys.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
     <value>Opent de opgegeven URL, normaliter in je standaard browser.
 
-Om &apos;privémodus&apos; te gebruiken, moet je een specifieke browser toevoegen in Configuratie -&gt; Externe Programma&apos;s.
+Om 'privémodus' te gebruiken, moet je een specifieke browser toevoegen in Configuratie -&gt; Externe Programma's.
 
-Als je alleen een scherm wilt met een specifieke URL (niet een complete browser), gebruik dan een &apos;WebView&apos; commando.</value>
+Als je alleen een scherm wilt met een specifieke URL (niet een complete browser), gebruik dan een 'WebView' commando.</value>
   </data>
   <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
     <value>Vergrendelt de huidige sessie.</value>
@@ -1267,22 +1268,22 @@ Als je alleen een scherm wilt met een specifieke URL (niet een complete browser)
     <value>Logt de huidige sessie uit.</value>
   </data>
   <data name="CommandsManager_MediaMuteCommandDescription" xml:space="preserve">
-    <value>Simuleert de &apos;demp&apos; (mute) knop.</value>
+    <value>Simuleert de 'demp' (mute) knop.</value>
   </data>
   <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
-    <value>Simuleert de &apos;media volgende&apos; knop.</value>
+    <value>Simuleert de 'media volgende' knop.</value>
   </data>
   <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
-    <value>Simuleert de &apos;media afspelen/pauze&apos; knop.</value>
+    <value>Simuleert de 'media afspelen/pauze' knop.</value>
   </data>
   <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
-    <value>Simuleert de &apos;media vorige&apos; knop.</value>
+    <value>Simuleert de 'media vorige' knop.</value>
   </data>
   <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
-    <value>Simuleert de &apos;volume lager&apos; knop.</value>
+    <value>Simuleert de 'volume lager' knop.</value>
   </data>
   <data name="CommandsManager_MediaVolumeUpCommandDescription" xml:space="preserve">
-    <value>Simuleert de &apos;volume hoger&apos; knop.</value>
+    <value>Simuleert de 'volume hoger' knop.</value>
   </data>
   <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
     <value>Simuleert het indrukken van meerdere toetsen:
@@ -1291,7 +1292,7 @@ Je moet [ ] om elke toets heen zetten, anders kan HASS.Agent ze niet onderscheid
 
 Er zijn een paar trucs die je kunt gebruiken:
 
-- Als je een haakje wilt indrukken, &apos;escape&apos; die dan, dus [ is [\[] en ] is [\]]
+- Als je een haakje wilt indrukken, 'escape' die dan, dus [ is [\[] en ] is [\]]
 
 - Speciale tekens moeten tussen { }, zoals {TAB} of {UP}
 
@@ -1316,12 +1317,12 @@ Handig om bijvoorbeeld HASS.Agent te forceren om al je sensoren te updaten na ee
   <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
     <value>Herstart de machine na één minuut.
 
-Tip: per ongeluk geactiveerd? Voer &apos;shutdown /a&apos; uit om te annuleren.</value>
+Tip: per ongeluk geactiveerd? Voer 'shutdown /a' uit om te annuleren.</value>
   </data>
   <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
     <value>Sluit de machine af na één minuut.
 
-Tip: per ongeluk geactiveerd? Voer &apos;shutdown /a&apos; uit om te annuleren.</value>
+Tip: per ongeluk geactiveerd? Voer 'shutdown /a' uit om te annuleren.</value>
   </data>
   <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
     <value>Zet de machine in slaap modus.
@@ -1331,7 +1332,7 @@ Info: vanwege een limiet van Windows, werkt dit alleen als hibernation uitgescha
 Je kunt iets als NirCmd (http://www.nirsoft.net/utils/nircmd.html) gebruiken om dit te omzeilen.</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox1" xml:space="preserve">
-    <value>Voer de locatie van je browser&apos;s binary in (.exe bestand).</value>
+    <value>Voer de locatie van je browser's binary in (.exe bestand).</value>
   </data>
   <data name="ConfigExternalTools_ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox2" xml:space="preserve">
     <value>De opgegeven binary is niet gevonden.</value>
@@ -1350,7 +1351,7 @@ Controleer de logs voor meer info.</value>
     <value>Voer een geldige API sleutel in.</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox2" xml:space="preserve">
-    <value>Voeg je Home Assistant&apos;s URI in.</value>
+    <value>Voeg je Home Assistant's URI in.</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox3" xml:space="preserve">
     <value>Kan niet verbinden, de volgende error werd opgegeven:
@@ -1385,7 +1386,7 @@ Ter info: dit test alleen of lokaal notificaties getoond kunnen worden!</value>
   <data name="ConfigNotifications_BtnExecutePortReservation_MessageBox1" xml:space="preserve">
     <value>Er ging iets mis!
 
-Probeer handmatig het vereiste commando uit te voeren. Die is gekopieerd naar je klembord, je hoeft &apos;m alleen maar te plakken in een &apos;command prompt&apos; met verhoogde privileges.
+Probeer handmatig het vereiste commando uit te voeren. Die is gekopieerd naar je klembord, je hoeft 'm alleen maar te plakken in een 'command prompt' met verhoogde privileges.
 
 Vergeet niet om de poort van je firewall regel ook aan te passen.</value>
   </data>
@@ -1410,7 +1411,7 @@ Vergeet niet om de poort van je firewall regel ook aan te passen.</value>
 Controleer de HASS.Agent (niet de service) logs voor meer info.</value>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
-    <value>De service staat op &apos;uitgeschakeld&apos;, dus kan niet gestart worden.
+    <value>De service staat op 'uitgeschakeld', dus kan niet gestart worden.
 
 Schakel eerst de service in, en probeer het dan opnieuw.</value>
   </data>
@@ -1478,7 +1479,7 @@ Controleer de logs voor meer info.</value>
     <value>Vul een geldige API sleutel in.</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox2" xml:space="preserve">
-    <value>Vul Home Assistant&apos;s URI in.</value>
+    <value>Vul Home Assistant's URI in.</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox3" xml:space="preserve">
     <value>Kan niet verbinden, de volgende error was teruggegeven:
@@ -1494,7 +1495,7 @@ Home Assistant versie: {0}</value>
     <value>testen ..</value>
   </data>
   <data name="ServiceCommands_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Er is iets mis gegaan bij het opslaan van de commando&apos;s, controleer de logs voor meer info.</value>
+    <value>Er is iets mis gegaan bij het opslaan van de commando's, controleer de logs voor meer info.</value>
   </data>
   <data name="ServiceCommands_BtnStore_Storing" xml:space="preserve">
     <value>opslaan en registreren, ogenblik geduld ..</value>
@@ -1506,9 +1507,9 @@ Home Assistant versie: {0}</value>
     <value>verbinden met de service is gefaald</value>
   </data>
   <data name="ServiceConnect_FailedMessage" xml:space="preserve">
-    <value>The service is niet gevonden! Je kunt &apos;m installeren en beheren vanuit het configuratie paneel.
+    <value>The service is niet gevonden! Je kunt 'm installeren en beheren vanuit het configuratie paneel.
 
-Wanneer hij weer draait, kun je hier terugkomen om de commando&apos;s en sensoren te configureren.</value>
+Wanneer hij weer draait, kun je hier terugkomen om de commando's en sensoren te configureren.</value>
   </data>
   <data name="ServiceConnect_CommunicationFailed" xml:space="preserve">
     <value>communiceren met de service is gefaald</value>
@@ -1543,10 +1544,10 @@ Je kunt de logs openen en de service beheren via het configuratie paneel.</value
 Je kunt de logs openen en de service beheren via het configuratie paneel.</value>
   </data>
   <data name="ServiceConnect_CommandsFailed" xml:space="preserve">
-    <value>ophalen geconfigureerde commando&apos;s gefaald</value>
+    <value>ophalen geconfigureerde commando's gefaald</value>
   </data>
   <data name="ServiceConnect_CommandsFailedMessage" xml:space="preserve">
-    <value>De service heeft een fout teruggegeven tijdens het ophalen van de opgeslagen commando&apos;s. Controleer de logs voor meer info.
+    <value>De service heeft een fout teruggegeven tijdens het ophalen van de opgeslagen commando's. Controleer de logs voor meer info.
 
 Je kunt de logs openen en de service beheren via het configuratie paneel.</value>
   </data>
@@ -1586,7 +1587,7 @@ Leeglaten om ze allemaal te laten verbinden.</value>
   <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
     <value>Met deze naam registreert de satelliet service zichzelf bij Home Assistant.
 
-Standaard is het je PC naam plus &apos;-satellite&apos;.</value>
+Standaard is het je PC naam plus '-satellite'.</value>
   </data>
   <data name="ServiceGeneral_LblDisconGraceInfo_MessageBox1" xml:space="preserve">
     <value>De hoeveelheid tijd dat de satelliet service wacht voordat hij een verbroken verbinding met de MQTT broker meldt.</value>
@@ -1644,7 +1645,7 @@ Controleer de logs voor meer informatie.</value>
     <value>opslaan en registreren, ogenblik geduld ..</value>
   </data>
   <data name="CommandsConfig_BtnStore_MessageBox1" xml:space="preserve">
-    <value>Er is iets mis gegaan bij het opslaan van de commando&apos;s, controleer de logs voor meer info.</value>
+    <value>Er is iets mis gegaan bij het opslaan van de commando's, controleer de logs voor meer info.</value>
   </data>
   <data name="CommandsMod_Title_NewCommand" xml:space="preserve">
     <value>Nieuwe Commando</value>
@@ -1668,12 +1669,12 @@ Controleer de logs voor meer informatie.</value>
     <value>Er is al een commando met die naam. Weet je zeker dat je door wilt gaan?</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox4" xml:space="preserve">
-    <value>Als je geen commando invult, kun je deze entiteit alleen gebruiken met een &apos;actie&apos; waarde via Home Assistant. Uitvoeren in de huidige vorm doet niks.
+    <value>Als je geen commando invult, kun je deze entiteit alleen gebruiken met een 'actie' waarde via Home Assistant. Uitvoeren in de huidige vorm doet niks.
 
 Weet je zeker dat je dit wilt?</value>
   </data>
   <data name="CommandsMod_MessageBox_Action" xml:space="preserve">
-    <value>Als je geen commando of script invult, kun je deze entiteit alleen gebruiken met een &apos;actie&apos; waarde via Home Assistant. Uitvoeren in de huidige vorm doet niks.
+    <value>Als je geen commando of script invult, kun je deze entiteit alleen gebruiken met een 'actie' waarde via Home Assistant. Uitvoeren in de huidige vorm doet niks.
 
 Weet je zeker dat je dit wilt?</value>
   </data>
@@ -1684,7 +1685,7 @@ Weet je zeker dat je dit wilt?</value>
     <value>Controleer van keys gefaald: {0}</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
-    <value>Als je geen URL invult, kun je deze entiteit alleen gebruiken met een &apos;actie&apos; waarde via Home Assistant. Uitvoeren in de huidige vorm doet niks.
+    <value>Als je geen URL invult, kun je deze entiteit alleen gebruiken met een 'actie' waarde via Home Assistant. Uitvoeren in de huidige vorm doet niks.
 
 Weet je zeker dat je dit wilt?</value>
   </data>
@@ -1730,10 +1731,10 @@ configureer een executor, anders kan het commando niet uitvoeren</value>
     <value>Dat betekent dat het alleen bestanden kan opslaan en aanpassen op bepaalde plekken,</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
-    <value>zoals de &apos;%USERPROFILE%\AppData\LocalLow&apos; map of</value>
+    <value>zoals de '%USERPROFILE%\AppData\LocalLow' map of</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
-    <value>de &apos;HKEY_CURRENT_USER\Software\AppDataLow&apos; register sleutel.</value>
+    <value>de 'HKEY_CURRENT_USER\Software\AppDataLow' register sleutel.</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
     <value>Je kunt het beste je commando testen om zeker te weten dat hij hier niet door wordt beïnvloed.</value>
@@ -1847,11 +1848,11 @@ configureer een executor, anders kan het commando niet uitvoeren</value>
   <data name="Configuration_ProcessChanges_MessageBox1" xml:space="preserve">
     <value>Je hebt je apparaatnaam aangepast.
 
-Al je sensoren en commando&apos;s worden nu ongepubliceerd, waarna HASS.Agent zal herstarten en ze daarna opnieuw zal publiceren.
+Al je sensoren en commando's worden nu ongepubliceerd, waarna HASS.Agent zal herstarten en ze daarna opnieuw zal publiceren.
 
 Geen zorgen, ze behouden hun huidige namen, dus al je automatiseringen en scripts blijven werken.
 
-Ter info: de naam zal &apos;opgeschoond&apos; worden, wat betekent dat alles behalve letters, cijfers en spaties wordt omgezet naar een laag streepje. Dit is vereist door HA.</value>
+Ter info: de naam zal 'opgeschoond' worden, wat betekent dat alles behalve letters, cijfers en spaties wordt omgezet naar een laag streepje. Dit is vereist door HA.</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox2" xml:space="preserve">
     <value>Je hebt de poort van de lokale API aangepast. Deze nieuwe poort moet gereserveerd wordt.
@@ -1862,7 +1863,7 @@ Je krijgt een UAC verzoek te zien om dat te doen, deze graag toestemming geven.<
   <data name="Configuration_ProcessChanges_MessageBox3" xml:space="preserve">
     <value>Er is iets misgegaan!
 
-Voer het vereiste commando handmatig uit. Hij is gekopieerd naar je klembord, je hoeft &apos;m alleen maar te plakken in een &apos;command prompt&apos; met verhoogde privileges.
+Voer het vereiste commando handmatig uit. Hij is gekopieerd naar je klembord, je hoeft 'm alleen maar te plakken in een 'command prompt' met verhoogde privileges.
 
 Vergeet niet om de poort van je firewall regel ook aan te passen.</value>
   </data>
@@ -1883,7 +1884,7 @@ Wil je nu herstarten?</value>
   <data name="Main_Load_MessageBox1" xml:space="preserve">
     <value>Er is iets misgegaan bij het laden van je instellingen.
 
-Controleer appsettings.json in de &apos;config&apos; subfolder, or verwijder &apos;m gewoon om schoon te starten.</value>
+Controleer appsettings.json in de 'config' subfolder, or verwijder 'm gewoon om schoon te starten.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="Main_Load_MessageBox2" xml:space="preserve">
@@ -1896,7 +1897,7 @@ Controleer de logs en rapporteer eventuele bugs op GitHub.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="Main_BtnCommandsManager_Ready" xml:space="preserve">
-    <value>&amp;commando&apos;s</value>
+    <value>&amp;commando's</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="Main_Checking" xml:space="preserve">
@@ -2039,7 +2040,7 @@ Controleer of er niet nog een andere instantie van HASS.Agent actief is, en of d
   <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
     <value>Geeft informatie over meerdere aspecten van het geluid van je apparaat:
 
-Huidige piek volumeniveau (kan gebruikt worden als een simpele &apos;speelt er iets&apos; waarde).
+Huidige piek volumeniveau (kan gebruikt worden als een simpele 'speelt er iets' waarde).
 
 Standaard geluidsapparaat: naam, status en volume.
 
@@ -2078,7 +2079,7 @@ Pakt momenteel het volume van je standaardapparaat.</value>
   <data name="SensorsManager_LastBootSensorDescription" xml:space="preserve">
     <value>Geeft een datetime waarde met het laatste moment dat het systeem (her)startte.
 
-Belangrijk: Windows&apos; FastBoot optie kan deze waarde beïnvloeden, omdat dat een vorm van hibernation is. Je kunt het uitschakelen via Energiebeheer. Het maakt niet veel verschil voor moderne machines met SSDs, maar het uitschakelen ervan zorgt ervoor dat je altijd een schone lei hebt na een herstart.</value>
+Belangrijk: Windows' FastBoot optie kan deze waarde beïnvloeden, omdat dat een vorm van hibernation is. Je kunt het uitschakelen via Energiebeheer. Het maakt niet veel verschil voor moderne machines met SSDs, maar het uitschakelen ervan zorgt ervoor dat je altijd een schone lei hebt na een herstart.</value>
   </data>
   <data name="SensorsManager_LastSystemStateChangeSensorDescription" xml:space="preserve">
     <value>Geeft de volgende systeemstatus veranderingen:
@@ -2120,7 +2121,7 @@ Categorie: Processor
 Teller: % Processor Time
 Instance: _Total
 
-Je kunt de tellers verkennen via Windows&apos; &apos;perfmon.exe&apos; applicatie.</value>
+Je kunt de tellers verkennen via Windows' 'perfmon.exe' applicatie.</value>
   </data>
   <data name="SensorsManager_ProcessActiveSensorDescription" xml:space="preserve">
     <value>Geeft het aantal actieve instanties van het proces.</value>
@@ -2129,7 +2130,7 @@ Je kunt de tellers verkennen via Windows&apos; &apos;perfmon.exe&apos; applicati
   <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
     <value>Geeft de staat van de opgegeven service: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending or Paused.
 
-Zorg dat je de &apos;Service naam&apos; geeft, niet de &apos;Weergavenaam&apos;.</value>
+Zorg dat je de 'Service naam' geeft, niet de 'Weergavenaam'.</value>
   </data>
   <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
     <value>Geeft de huidige sessie staat:
@@ -2155,7 +2156,7 @@ Notitie: als hij gebruikt wordt in de satelliet service, zal hij geen gebruikers
     <comment>Fuzzy</comment>
   </data>
   <data name="SensorsManager_WindowsUpdatesSensorsDescription" xml:space="preserve">
-    <value>Geeft een sensor met het aantal beschikbare driver updates, een sensor met het aantal beschikbare software updates, een sensor met info over de beschikbare driver updates (titel, kb, artikel id&apos;s, verborgen, type en categorieën) en een sensor met hetzelfde voor de beschikbare software updates.
+    <value>Geeft een sensor met het aantal beschikbare driver updates, een sensor met het aantal beschikbare software updates, een sensor met info over de beschikbare driver updates (titel, kb, artikel id's, verborgen, type en categorieën) en een sensor met hetzelfde voor de beschikbare software updates.
 
 Dit is een duur verzoek, dus de aanbevolen interval is 15 minuten (900 seconden). Maar de ondergrens is 10 minuten, als je een lagere waarde geeft krijg je de laatst-bekende lijst terug.</value>
     <comment>Fuzzy</comment>
@@ -2179,12 +2180,12 @@ Dit is een duur verzoek, dus de aanbevolen interval is 15 minuten (900 seconden)
 {0}</value>
   </data>
   <data name="StoredCommands_Load_MessageBox1" xml:space="preserve">
-    <value>Fout tijdens laden commando&apos;s:
+    <value>Fout tijdens laden commando's:
 
 {0}</value>
   </data>
   <data name="StoredCommands_Store_MessageBox1" xml:space="preserve">
-    <value>Fout tijdens opslaan commando&apos;s:
+    <value>Fout tijdens opslaan commando's:
 
 {0}</value>
   </data>
@@ -2609,7 +2610,7 @@ Wil je alsnog met de huidige waardes testen?</value>
     <value>ApplicatieGestart</value>
   </data>
   <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
-    <value>Je kunt de satelliet service gebruiken om sensoren en commando&apos;s uit te voeren zonder ingelogd te hoeven zijn. Niet alle types zijn beschikbaar, bijvoorbeeld het &apos;LanceerUrl&apos; commando kan alleen als regulier commando toegevoegd worden.</value>
+    <value>Je kunt de satelliet service gebruiken om sensoren en commando's uit te voeren zonder ingelogd te hoeven zijn. Niet alle types zijn beschikbaar, bijvoorbeeld het 'LanceerUrl' commando kan alleen als regulier commando toegevoegd worden.</value>
   </data>
   <data name="SensorsConfig_ClmValue" xml:space="preserve">
     <value>laatst bekende waarde</value>
@@ -2628,24 +2629,24 @@ Controleer of er geen andere HASS.Agent instanties actief zijn, en of de poort b
   <data name="CommandsManager_WebViewCommandDescription" xml:space="preserve">
     <value>Toont een scherm met de opgegeven URL.
 
-Dit wijkt af van het &apos;LanceerUrl&apos; commando in dat het geen volledige browser laadt, alleen de opgegeven URL in een eigen scherm.
+Dit wijkt af van het 'LanceerUrl' commando in dat het geen volledige browser laadt, alleen de opgegeven URL in een eigen scherm.
 
 Je kunt dit bijvoorbeeld gebruiken om snel een dashboard van Home Assistant te tonen.
 
 Standaard slaat hij cookies oneindig op, dus je hoeft maar één keer in te loggen.</value>
   </data>
   <data name="HassDomain_HASSAgentCommands" xml:space="preserve">
-    <value>HASS.Agent Commando&apos;s</value>
+    <value>HASS.Agent Commando's</value>
   </data>
   <data name="CommandsManager_CommandsManager_SendWindowToFrontCommandDescription" xml:space="preserve">
-    <value>Zoekt het opgegeven proces, en probeert z&apos;n hoofdscherm naar de voorgrond te halen.
+    <value>Zoekt het opgegeven proces, en probeert z'n hoofdscherm naar de voorgrond te halen.
 
 Als de applicatie geminimaliseerd is, wordt hij hersteld.
 
-Voorbeeld: als je VLC naar de voorgrond wilt sturen, gebruik dan &apos;vlc&apos;.</value>
+Voorbeeld: als je VLC naar de voorgrond wilt sturen, gebruik dan 'vlc'.</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
-    <value>Als je het commando niet configureert, kan je deze entiteit alleen gebruiken met een &apos;actie&apos; waarde via Home Assistant en hij toont met de standaard instellingen. Uitvoeren zonder een actie doet niks.
+    <value>Als je het commando niet configureert, kan je deze entiteit alleen gebruiken met een 'actie' waarde via Home Assistant en hij toont met de standaard instellingen. Uitvoeren zonder een actie doet niks.
 
 Weet je zeker dat je dit wilt?</value>
   </data>
@@ -2687,7 +2688,7 @@ Ter info: deze melding toont éénmalig.</value>
     <value>lokal&amp;e api uitvoeren</value>
   </data>
   <data name="ConfigLocalApi_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent heeft z&apos;n eigen lokale API, zodat Home Assistant verzoeken kan sturen (bijvoorbeeld om een notificatie te versturen). Je kunt hem hier globlaal configureren, en daarna kun je de afhankelijke onderdelen configureren (momenteel notificaties en mediaspeler).
+    <value>HASS.Agent heeft z'n eigen lokale API, zodat Home Assistant verzoeken kan sturen (bijvoorbeeld om een notificatie te versturen). Je kunt hem hier globlaal configureren, en daarna kun je de afhankelijke onderdelen configureren (momenteel notificaties en mediaspeler).
 
 Notitie: dit is niet vereist om de nieuwe integratie te laten werken. Alleen inschakelen en gebruiken als je geen MQTT gebruikt.</value>
     <comment>Fuzzy</comment>
@@ -2741,14 +2742,14 @@ Notitie: dit is niet vereist om de nieuwe integratie te laten werken. Alleen ins
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigMediaPlayer_LblLocalApiDisabled" xml:space="preserve">
-    <value>de lokale API is uitgeschakeld, maar de mediaspeler heeft &apos;m nodig om te functioneren</value>
+    <value>de lokale API is uitgeschakeld, maar de mediaspeler heeft 'm nodig om te functioneren</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigMqtt_CbMqttTls" xml:space="preserve">
     <value>&amp;TLS</value>
   </data>
   <data name="ConfigNotifications_LblLocalApiDisabled" xml:space="preserve">
-    <value>de lokale API is uitgeschakeld, maar de mediaspeler heeft &apos;m nodig om te functioneren</value>
+    <value>de lokale API is uitgeschakeld, maar de mediaspeler heeft 'm nodig om te functioneren</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigTrayIcon_BtnShowWebViewPreview" xml:space="preserve">
@@ -2785,10 +2786,10 @@ Notitie: dit is niet vereist om de nieuwe integratie te laten werken. Alleen ins
     <value>Systeemvak Pictogram</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
-    <value>Je invoertaal &apos;{0}&apos; staat erom bekend te botsen met de standaard CTRL-ALT-Q sneltoets. Stel daarom je eigen in.</value>
+    <value>Je invoertaal '{0}' staat erom bekend te botsen met de standaard CTRL-ALT-Q sneltoets. Stel daarom je eigen in.</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
-    <value>Je invoertaal &apos;{0}&apos; is onbekend, en kan botsen met de standaard CTRL-ALT-Q sneltoets. Controleer dit voor de zekerheid. Als het zo is, overweeg dan een ticket te openen op GitHub om &apos;m aan de lijst toe te laten voegen.</value>
+    <value>Je invoertaal '{0}' is onbekend, en kan botsen met de standaard CTRL-ALT-Q sneltoets. Controleer dit voor de zekerheid. Als het zo is, overweeg dan een ticket te openen op GitHub om 'm aan de lijst toe te laten voegen.</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
     <value>geen toetsen gevonden</value>
@@ -2800,7 +2801,7 @@ Notitie: dit is niet vereist om de nieuwe integratie te laten werken. Alleen ins
     <value>fout tijdens verwerken toetsen, controleer de logs voor meer info</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
-    <value>het aantal &apos;[&apos; haakjes komt niet overeen met het aantal &apos;]&apos; haakjes ({0} tegenover {1})</value>
+    <value>het aantal '[' haakjes komt niet overeen met het aantal ']' haakjes ({0} tegenover {1})</value>
   </data>
   <data name="Help_LblDocumentation" xml:space="preserve">
     <value>Documentatie</value>
@@ -2852,7 +2853,7 @@ Dit is makkelijk via HACS, maar je kunt ook handmatig installeren. Bezoek de lin
     <value>activeer &amp;notificaties</value>
   </data>
   <data name="OnboardingLocalApi_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent gebruikt z&apos;n eigen ingebouwde API, zodat Home Assistant verzoeken kan sturen (zoals notificaties of tekst-naar-spraak).
+    <value>HASS.Agent gebruikt z'n eigen ingebouwde API, zodat Home Assistant verzoeken kan sturen (zoals notificaties of tekst-naar-spraak).
 
 Wil je dit activeren?</value>
   </data>
@@ -2860,7 +2861,7 @@ Wil je dit activeren?</value>
     <value>Je kunt kiezen welke modules te wilt activeren. Ze vereisen HA integraties, maar geen zorgen, de volgende pagina geeft je meer info over hoe je ze in kunt stellen.</value>
   </data>
   <data name="OnboardingLocalApi_LblTip1" xml:space="preserve">
-    <value>Ter info: 5115 is de standaard poort, verander &apos;m alleen als je dit ook in Home Assistant hebt gedaan.</value>
+    <value>Ter info: 5115 is de standaard poort, verander 'm alleen als je dit ook in Home Assistant hebt gedaan.</value>
   </data>
   <data name="OnboardingMqtt_CbMqttTls" xml:space="preserve">
     <value>&amp;TLS</value>
@@ -2903,7 +2904,7 @@ Wil je die versie gebruiken?</value>
     <value>grootte</value>
   </data>
   <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
-    <value>tip: druk op &apos;esc&apos; om een webview te sluiten</value>
+    <value>tip: druk op 'esc' om een webview te sluiten</value>
   </data>
   <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
     <value>&amp;URL</value>
@@ -2926,7 +2927,7 @@ Controleer of het keycode veld focus heeft, en druk dan op de toets die je gesim
     <value>status notificaties inschakelen</value>
   </data>
   <data name="ConfigGeneral_LblInfo5" xml:space="preserve">
-    <value>HASS.Agent zal je apparaatnaam opschonen, om zeker te zijn dat HA &apos;m accepteert. Je kunt dit uitschakelen als je zeker weet dat je naam wordt geaccepteerd.</value>
+    <value>HASS.Agent zal je apparaatnaam opschonen, om zeker te zijn dat HA 'm accepteert. Je kunt dit uitschakelen als je zeker weet dat je naam wordt geaccepteerd.</value>
   </data>
   <data name="ConfigGeneral_LblInfo6" xml:space="preserve">
     <value>Als je wilt, kun je status notificaties compleet uitschakelen. HASS.Agent zal je niet melden dat een verbinding verbroken of hersteld is.</value>
@@ -2934,7 +2935,7 @@ Controleer of het keycode veld focus heeft, en druk dan op de toets die je gesim
   <data name="Configuration_ProcessChanges_MessageBox6" xml:space="preserve">
     <value>Je hebt je apparaatnaam aangepast.
 
-Al je sensoren en commando&apos;s worden nu ongepubliceerd, waarna HASS.Agent zal herstarten en ze daarna opnieuw zal publiceren.
+Al je sensoren en commando's worden nu ongepubliceerd, waarna HASS.Agent zal herstarten en ze daarna opnieuw zal publiceren.
 
 Geen zorgen, ze behouden hun huidige namen, dus al je automatiseringen en scripts blijven werken.
 
@@ -2998,7 +2999,7 @@ Ter info: je hebt opschoning uitgeschakeld, dus verzeker je ervan dat je apparaa
     <value>Zet alle beeldschermen in slaap (laag energieverbruik) modus.</value>
   </data>
   <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
-    <value>Probeert alle beeldschermen wakker te maken door de &apos;pijl omhoog&apos; knop te simuleren.</value>
+    <value>Probeert alle beeldschermen wakker te maken door de 'pijl omhoog' knop te simuleren.</value>
   </data>
   <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
     <value>Stelt de volume van de huidige standaard geluidapparaat in op het opgegeven niveau.</value>
@@ -3010,7 +3011,7 @@ Ter info: je hebt opschoning uitgeschakeld, dus verzeker je ervan dat je apparaa
     <value>Commando</value>
   </data>
   <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
-    <value>Als je geen volume waarde invult, kun je deze entiteit alleen gebruiken met een &apos;actie&apos; waarde via Home Assistant. Zonder activeren doet niks.
+    <value>Als je geen volume waarde invult, kun je deze entiteit alleen gebruiken met een 'actie' waarde via Home Assistant. Zonder activeren doet niks.
 
 Weet je zeker dat je dit wilt?</value>
   </data>
@@ -3025,12 +3026,12 @@ Wil je deze variant gebruiken?</value>
     <value>Je API token ziet er verkeerd uit. Controleer dat je de hele token geselecteerd hebt (geen CTRL+A of dubbelklik gebruiken). 
 Er zouden drie secties moeten zijn (gescheiden door twee punten).
 
-Weet je zeker dat je &apos;m zo wilt gebruiken?</value>
+Weet je zeker dat je 'm zo wilt gebruiken?</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox6" xml:space="preserve">
-    <value>Je URI ziet er verkeerd uit. Het zou moeten lijken op &apos;http://homeassistant.local:8123&apos; of &apos;https://192.168.0.1:8123&apos;.
+    <value>Je URI ziet er verkeerd uit. Het zou moeten lijken op 'http://homeassistant.local:8123' of 'https://192.168.0.1:8123'.
 
-Weet je zeker dat je &apos;m zo wilt gebruiken?</value>
+Weet je zeker dat je 'm zo wilt gebruiken?</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_Testing" xml:space="preserve">
     <value>testen ..</value>
@@ -3042,7 +3043,7 @@ Weet je zeker dat je &apos;m zo wilt gebruiken?</value>
     <value>mqtt inschakelen</value>
   </data>
   <data name="ConfigMqtt_LblMqttDisabledWarning" xml:space="preserve">
-    <value>zonder mqtt, zullen commando&apos;s en sensoren niet werken!</value>
+    <value>zonder mqtt, zullen commando's en sensoren niet werken!</value>
   </data>
   <data name="ConfigNotifications_LblConnectivityDisabled" xml:space="preserve">
     <value>zowel de lokale API als MQTT zijn uitgeschakeld, maar de integratie heeft ten minste één nodig om te werken</value>
@@ -3053,10 +3054,10 @@ Weet je zeker dat je &apos;m zo wilt gebruiken?</value>
   <data name="ConfigService_BtnManageService_MessageBox1" xml:space="preserve">
     <value>De service is momenteel gestopt, dus je kunt hem niet configureren.
 
-Zorg dat je &apos;m eerst geactiveerd en gestart hebt.</value>
+Zorg dat je 'm eerst geactiveerd en gestart hebt.</value>
   </data>
   <data name="ConfigService_LblInfo5" xml:space="preserve">
-    <value>Als je de service wilt beheren (commando&apos;s en sensors toevoegen, instellingen aanpassen) dan kan dat hier, of door de &apos;satellite service&apos; knop op het hoofdscherm.</value>
+    <value>Als je de service wilt beheren (commando's en sensors toevoegen, instellingen aanpassen) dan kan dat hier, of door de 'satellite service' knop op het hoofdscherm.</value>
   </data>
   <data name="ConfigTrayIcon_CbWebViewShowMenuOnLeftClick" xml:space="preserve">
     <value>toon standaard menu bij linker muisknop klik</value>
@@ -3065,17 +3066,17 @@ Zorg dat je &apos;m eerst geactiveerd en gestart hebt.</value>
     <value>Je Home Assistant API token ziet er verkeerd uit. Controleer dat je de hele token geselecteerd hebt (geen CTRL+A of dubbelklik gebruiken). 
 Er zouden drie secties moeten zijn (gescheiden door twee punten).
 
-Weet je zeker dat je &apos;m zo wilt gebruiken?</value>
+Weet je zeker dat je 'm zo wilt gebruiken?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
-    <value>Je Home Assistant URI ziet er verkeerd uit. Het zou moeten lijken op &apos;http://homeassistant.local:8123&apos; of &apos;https://192.168.0.1:8123&apos;.
+    <value>Je Home Assistant URI ziet er verkeerd uit. Het zou moeten lijken op 'http://homeassistant.local:8123' of 'https://192.168.0.1:8123'.
 
-Weet je zeker dat je &apos;m zo wilt gebruiken?</value>
+Weet je zeker dat je 'm zo wilt gebruiken?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
-    <value>Je MQTT broker URI ziet er verkeerd uit. Het zou moeten lijken op &apos;homeassistant.local&apos; or &apos;192.168.0.1&apos;.
+    <value>Je MQTT broker URI ziet er verkeerd uit. Het zou moeten lijken op 'homeassistant.local' or '192.168.0.1'.
 
-Weet je zeker dat je &apos;m zo wilt gebruiken?</value>
+Weet je zeker dat je 'm zo wilt gebruiken?</value>
   </data>
   <data name="Donate_BtnClose" xml:space="preserve">
     <value>sluiten</value>
@@ -3088,7 +3089,7 @@ Weet je zeker dat je &apos;m zo wilt gebruiken?</value>
 
 Het ontwikkelen en onderhouden van deze tool (en alles wat erbij komt kijken, zoals support, deze vertaling en de documentatie) neemt een hoop tijd in beslag.
 
-Zoals de meeste ontwikkelaars draai ik op caffeïne - dus als je &apos;t kunt missen, wordt een kop koffie altijd erg gewaardeerd!</value>
+Zoals de meeste ontwikkelaars draai ik op caffeïne - dus als je 't kunt missen, wordt een kop koffie altijd erg gewaardeerd!</value>
   </data>
   <data name="Donate_Title" xml:space="preserve">
     <value>Doneren</value>
@@ -3103,15 +3104,15 @@ Zoals de meeste ontwikkelaars draai ik op caffeïne - dus als je &apos;t kunt mi
     <value>Je API token ziet er verkeerd uit. Controleer dat je de hele token geselecteerd hebt (geen CTRL+A of dubbelklik gebruiken). 
 Er zouden drie secties moeten zijn (gescheiden door twee punten).
 
-Weet je zeker dat je &apos;m zo wilt gebruiken?</value>
+Weet je zeker dat je 'm zo wilt gebruiken?</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox6" xml:space="preserve">
-    <value>Je URI ziet er verkeerd uit. Het zou moeten lijken op &apos;http://homeassistant.local:8123&apos; of &apos;https://192.168.0.1:8123&apos;.
+    <value>Je URI ziet er verkeerd uit. Het zou moeten lijken op 'http://homeassistant.local:8123' of 'https://192.168.0.1:8123'.
 
-Weet je zeker dat je &apos;m zo wilt gebruiken?</value>
+Weet je zeker dat je 'm zo wilt gebruiken?</value>
   </data>
   <data name="OnboardingDone_LblInfo6" xml:space="preserve">
-    <value>Het ontwikkelen en onderhouden van deze tool (en alles wat erbij komt kijken, zoals support, deze vertaling en de documentatie) neemt een hoop tijd in beslag. Zoals de meeste ontwikkelaars draai ik op caffeïne - dus als je &apos;t kunt missen, wordt een kop koffie altijd erg gewaardeerd!</value>
+    <value>Het ontwikkelen en onderhouden van deze tool (en alles wat erbij komt kijken, zoals support, deze vertaling en de documentatie) neemt een hoop tijd in beslag. Zoals de meeste ontwikkelaars draai ik op caffeïne - dus als je 't kunt missen, wordt een kop koffie altijd erg gewaardeerd!</value>
   </data>
   <data name="OnboardingDone_LblTip2" xml:space="preserve">
     <value>Tip: andere donatie methodes zijn beschikbaar in het Over scherm.</value>
@@ -3143,9 +3144,9 @@ Toont alleen apparaten die zijn gezien sinds het laatste rapport, oftewel, zodra
   <data name="SensorsManager_GeoLocationSensorDescription" xml:space="preserve">
     <value>Geeft je huidige latitude, longitude en altitude als een kommagescheiden waarde.
 
-Verzeker dat Windows&apos; localisatieservices ingeschakeld zijn!
+Verzeker dat Windows' localisatieservices ingeschakeld zijn!
 
-Afhankelijk van je Windows versie, kan dit gevonden worden in het nieuwe configuratiescherm -&gt; &apos;privacy en beveiliging&apos; -&gt; &apos;locatie&apos;.</value>
+Afhankelijk van je Windows versie, kan dit gevonden worden in het nieuwe configuratiescherm -&gt; 'privacy en beveiliging' -&gt; 'locatie'.</value>
   </data>
   <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
     <value>Geeft de naam van het proces dat momenteel de microfoon gebruikt.
@@ -3231,7 +3232,7 @@ Wil je de logmap openen?</value>
     <value>error tijdens instellen opstartmodus, controleer logs</value>
   </data>
   <data name="WebView_InitializeAsync_MessageBox1" xml:space="preserve">
-    <value>Microsoft&apos;s WebView2 runtime is niet op je machine gevonden. Normaliter handelt de installatie dit af, maar je kunt het ook handmatig installeren.
+    <value>Microsoft's WebView2 runtime is niet op je machine gevonden. Normaliter handelt de installatie dit af, maar je kunt het ook handmatig installeren.
 
 Wil je de runtime installatie downloaden?</value>
   </data>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.pl.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.pl.resx
@@ -239,7 +239,7 @@ W ten sposób, cokolwiek robisz na swoim komputerze, zawsze możesz wchodzić w 
     <value>Niektóre elementy, takie jak obrazy wyświetlane w powiadomieniach, muszą być tymczasowo przechowywane lokalnie. Możesz
 skonfigurować, przez ile dni mają być przechowywane, zanim HASS.Agent je usunie.
 
-Aby zachować je na stałe, wpisz &quot;0&quot;.</value>
+Aby zachować je na stałe, wpisz "0".</value>
   </data>
   <data name="ConfigLogging_LblInfo1" xml:space="preserve">
     <value>Rozszerzone rejestrowanie logów zapewnia bardziej szczegółowe i wnikliwe informacje w przypadku, gdy domyślne rejestrowanie nie jest wystarczające.
@@ -775,7 +775,7 @@ HASS.Agent do nasłuchiwania na określonym porcie.</value>
     <value>HASS.Agent Aktualizacja</value>
   </data>
   <data name="Restart_LblInfo1" xml:space="preserve">
-    <value>Poczekaj na ponowne uruchomienie HASS.Agent&apos;a..</value>
+    <value>Poczekaj na ponowne uruchomienie HASS.Agent'a..</value>
   </data>
   <data name="Restart_LblTask1" xml:space="preserve">
     <value>Czakam na zamkniecie poprzedniej instancji..</value>
@@ -1199,7 +1199,7 @@ zgłaszaj błędy lub po prostu rozmawiaj o czymkolwiek.</value>
     <value>Pomoc</value>
   </data>
   <data name="Main_TsShow" xml:space="preserve">
-    <value>pokaż HASS.Agent&apos;a</value>
+    <value>pokaż HASS.Agent'a</value>
   </data>
   <data name="Main_TsShowQuickActions" xml:space="preserve">
     <value>pokaż szybkie akcje</value>
@@ -1277,7 +1277,7 @@ k&amp;onfiguracja</value>
     <value>szybkie akcje:</value>
   </data>
   <data name="Main_LblHomeAssistantApi" xml:space="preserve">
-    <value>api home assistant&apos;a:</value>
+    <value>api home assistant'a:</value>
   </data>
   <data name="Main_LblNotificationApi" xml:space="preserve">
     <value>api powiadomień</value>
@@ -1319,7 +1319,7 @@ k&amp;onfiguracja</value>
   <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
     <value>Wykonaj niestandardowe polecenie.
 
-Te polecenia działają bez podwyższonych uprawnień. Aby uruchomić z podwyższonym poziomem uprawnień, utwórz Zaplanowane zadanie i użyj &apos;schtasks /Run /TN &quot;NazwaZadania&quot;&apos; jako polecenia do wykonania zadania.
+Te polecenia działają bez podwyższonych uprawnień. Aby uruchomić z podwyższonym poziomem uprawnień, utwórz Zaplanowane zadanie i użyj 'schtasks /Run /TN "NazwaZadania"' jako polecenia do wykonania zadania.
 
 Lub włącz opcję „uruchom jako niską integralność”, aby uzyskać jeszcze bardziej rygorystyczne wykonanie.</value>
   </data>
@@ -1334,9 +1334,10 @@ Twoje polecenie jest dostarczane jako argument „tak jak jest”, więc w razie
   <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
     <value>Symuluje pojedyncze naciśnięcie klawisza.
 
-Możesz wybrać dowolną z tych wartości: https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+Kliknij pole tekstowe „Kod klucza” i naciśnij klawisz, który chcesz zasymulować. Odpowiedni kod zostanie wprowadzony.
+W przypadku klawisza TAB użyj LCTRL+TAB.
 
-Jeśli potrzebujesz więcej klawiszy i/lub modyfikatorów, takich jak CTRL, użyj polecenia WieleKlawiszy.</value>
+Jeśli potrzebujesz więcej klawiszy i/lub modyfikatorów, takich jak CTRL, użyj polecenia MultipleKeys.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
@@ -1402,12 +1403,12 @@ Przydatne na przykład, jeśli chcesz zmusić HASS.Agent do aktualizacji wszystk
   <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
     <value>Ponowne uruchomi maszynę po jednej minucie.
 
-Wskazówka: włączono przypadkowo? Uruchom &apos;shutdown /a&apos;, aby przerwać.</value>
+Wskazówka: włączono przypadkowo? Uruchom 'shutdown /a', aby przerwać.</value>
   </data>
   <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
     <value>Wyłączy maszynę po jednej minucie.
 
-Wskazówka: włączono przypadkowo? Uruchom &apos;shutdown /a&apos;, aby przerwać.</value>
+Wskazówka: włączono przypadkowo? Uruchom 'shutdown /a', aby przerwać.</value>
   </data>
   <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
     <value>Usypia maszynę.
@@ -1555,7 +1556,7 @@ Sprawdź logi, aby uzyskać więcej informacji.</value>
     <value>Aktywowanie Uruchomienie-przy-logowaniu..</value>
   </data>
   <data name="OnboardingStartup_Failed" xml:space="preserve">
-    <value>Coś poszło nie tak. Możesz spróbować ponownie, lub przejść do następnej strony i spróbować ponownie po ponownym uruchomieniu HASS.Agent&apos;a.</value>
+    <value>Coś poszło nie tak. Możesz spróbować ponownie, lub przejść do następnej strony i spróbować ponownie po ponownym uruchomieniu HASS.Agent'a.</value>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin_2" xml:space="preserve">
     <value>Włącz Uruchomienie-przy-logowaniu</value>
@@ -1663,7 +1664,7 @@ Czy jesteś pewien?</value>
     <value>Wybrane środowisko wykonania nie zostało znalezione. Wybierz nowe.</value>
   </data>
   <data name="ServiceGeneral_LblAuthIdInfo_MessageBox1" xml:space="preserve">
-    <value>Ustawia klucz autoryzacji, jeżeli chcesz aby tylko jedna instancja HASS.Agent&apos;a na tym komputerze łączyła się z usługą usługą Satellite.
+    <value>Ustawia klucz autoryzacji, jeżeli chcesz aby tylko jedna instancja HASS.Agent'a na tym komputerze łączyła się z usługą usługą Satellite.
 
 Tylko instancja z odpowiednim kluczem autoryzacji może się połączyć. 
 
@@ -1673,7 +1674,7 @@ Pozostaw puste aby pozwolić łączyć się wszystkim.</value>
   <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
     <value>Nazwa pod którą usługa  Satellite zostanie zarejestrowana w Home Assistant.
 
-Domyślnie jest to nazwa twojego komputera oraz &apos;-satellite&apos;.</value>
+Domyślnie jest to nazwa twojego komputera oraz '-satellite'.</value>
   </data>
   <data name="ServiceGeneral_LblDisconGraceInfo_MessageBox1" xml:space="preserve">
     <value>Czas po jakim usługa Satellite wyśle informacje o utracie połączenia przez MQTT.</value>
@@ -2132,7 +2133,7 @@ Upewnij się, że żadne inna instancja HASS.Agent nie jest uruchomiona, a port 
   <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
     <value>Zwraca informacje na temat urządzenia audio: 
 
-Aktualny maksymalny poziom głośności (może być używany jako prosta wartość &apos;czy coś aktualnie gra&apos;).
+Aktualny maksymalny poziom głośności (może być używany jako prosta wartość 'czy coś aktualnie gra').
 
 Domyślne urządzenie audio: nazwa, stan, głośność.
 
@@ -2212,7 +2213,7 @@ Category: Processor
 Counter: % Processor Time
 Instance: _Total
 
-Możesz odnaleźć liczniki wydajności przez narzędzie Windows &apos;perfmon.exe&apos;.</value>
+Możesz odnaleźć liczniki wydajności przez narzędzie Windows 'perfmon.exe'.</value>
   </data>
   <data name="SensorsManager_ProcessActiveSensorDescription" xml:space="preserve">
     <value>Zwraca ilość instancji danego procesu.</value>
@@ -2221,7 +2222,7 @@ Możesz odnaleźć liczniki wydajności przez narzędzie Windows &apos;perfmon.e
   <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
     <value>Zwraca stan usługi: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending or Paused.
 
-Upewnij się że wpisujesz &apos;Service name&apos;, nie &apos;Dispaly name&apos;.</value>
+Upewnij się że wpisujesz 'Service name', nie 'Dispaly name'.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
@@ -2702,7 +2703,7 @@ Czy chcesz użyć obecnej ścieżki?</value>
     <value>ApplicationStarted</value>
   </data>
   <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
-    <value>Możesz użyć usługi Satellite aby przesyłać czujniki i komendy bez potrzeby bycia zalogowanym. Nie wszystkie typy działają, na przykład komenda &apos;UruchomUrl&apos; może zostać dodana tylko jako normalna komenda.</value>
+    <value>Możesz użyć usługi Satellite aby przesyłać czujniki i komendy bez potrzeby bycia zalogowanym. Nie wszystkie typy działają, na przykład komenda 'UruchomUrl' może zostać dodana tylko jako normalna komenda.</value>
   </data>
   <data name="SensorsConfig_ClmValue" xml:space="preserve">
     <value>Ostatnie Znana Wartość</value>
@@ -2978,7 +2979,7 @@ Czy akceptujesz taką nazwę?</value>
     <value>Pokazuje nazwe okna</value>
   </data>
   <data name="WebViewCommandConfig_CbTopMost" xml:space="preserve">
-    <value>Ustawia okno jako &apos;&amp;Zawsze na wierzchu&apos;</value>
+    <value>Ustawia okno jako '&amp;Zawsze na wierzchu'</value>
   </data>
   <data name="WebViewCommandConfig_LblInfo1" xml:space="preserve">
     <value>Złap i przeciągnij okno aby ustalić rozmiar i miejsce komendy WebView</value>
@@ -3085,7 +3086,7 @@ Uwaga: wyłączyłeś czyszczenie nazw, więc upewnij się, że nazwa Twojego ur
     <value>Usypia wszystkie monitory (niski zużycie energii).</value>
   </data>
   <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
-    <value>Stara się wybudzić wszystkie monitory poprzez symulowanie wciśnięcia przycisku &quot;do góry&quot;.</value>
+    <value>Stara się wybudzić wszystkie monitory poprzez symulowanie wciśnięcia przycisku "do góry".</value>
   </data>
   <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
     <value>Ustawia poziom głośności domyślnego urządzenia na podaną wartość. </value>
@@ -3097,7 +3098,7 @@ Uwaga: wyłączyłeś czyszczenie nazw, więc upewnij się, że nazwa Twojego ur
     <value>komenda</value>
   </data>
   <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
-    <value>Nie podając żadnej wartości głośności musisz używać encji z &apos;akcją&apos; w Home Assistant. Uruchomienie jej tak jak teraz nie przyniesie żadnego efektu. 
+    <value>Nie podając żadnej wartości głośności musisz używać encji z 'akcją' w Home Assistant. Uruchomienie jej tak jak teraz nie przyniesie żadnego efektu. 
 
 Czy jesteś pewien?</value>
   </data>
@@ -3155,12 +3156,12 @@ Proszę włącz usługę aby ją skonfigurować.</value>
 Czy jesteś pewien, że chcesz użyć tego tokenu?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
-    <value>Twój adres Home Assistant wygląda na błędny. Powinien wyglądać mniej więcej tak &apos;http://homeassistant.local:8123&apos; lub tak &apos;https://192.168.0.1:8123&apos;.
+    <value>Twój adres Home Assistant wygląda na błędny. Powinien wyglądać mniej więcej tak 'http://homeassistant.local:8123' lub tak 'https://192.168.0.1:8123'.
 
 Jesteś pewien że chcesz używać takiego?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
-    <value>Twój adres brokera MQTT wygląda na błędny. Powinien wyglądać mniej więcej tak &apos;homeassistant.local&apos; lub tak &apos;192.168.0.1&apos;.
+    <value>Twój adres brokera MQTT wygląda na błędny. Powinien wyglądać mniej więcej tak 'homeassistant.local' lub tak '192.168.0.1'.
 
 Jesteś pewien że chcesz używać takiego?</value>
   </data>
@@ -3233,7 +3234,7 @@ Pokazuje tylko te urządzenia które zgłaszały się w okresie od ostatniego ra
 
 Upewnij się że lokalizacja jest włączona w systemie Windows!
 
-W zalezności od Twojej wersji Windows&apos;a opcje te możesz znaleźć w Ustawienia -&gt; Prywatność i Zabezpieczenia -&gt; Lokalizacja</value>
+W zalezności od Twojej wersji Windows'a opcje te możesz znaleźć w Ustawienia -&gt; Prywatność i Zabezpieczenia -&gt; Lokalizacja</value>
   </data>
   <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
     <value>Zwraca nazwę procesu który obecnie używa mikrofonu. 
@@ -3319,7 +3320,7 @@ Czy chcesz otworzyć plik log?</value>
     <value>Błąd podczas ustawiania trybu uruchamiania. Sprawdź logi, aby uzyskać więcej informacji.</value>
   </data>
   <data name="WebView_InitializeAsync_MessageBox1" xml:space="preserve">
-    <value>Na twoim komputerze nie ma zainstalowanego Microsoft&apos;s WebView2 runtime. Zazwyczaj jest on instalowany automatycznie, ale możesz to zrobić też ręcznie. 
+    <value>Na twoim komputerze nie ma zainstalowanego Microsoft's WebView2 runtime. Zazwyczaj jest on instalowany automatycznie, ale możesz to zrobić też ręcznie. 
 
 Czy chcesz pobrać plik instalacyjny?</value>
   </data>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.pt-br.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.pt-br.resx
@@ -131,7 +131,7 @@
 páginas dos componentes usados ​​para suas licenças individuais:</value>
   </data>
   <data name="About_LblInfo4" xml:space="preserve">
-    <value>Um grande &apos;obrigado&apos; aos desenvolvedores desses projetos, que foram gentis o
+    <value>Um grande 'obrigado' aos desenvolvedores desses projetos, que foram gentis o
 suficiente para compartilhar seu trabalho duro com o resto de nós, meros mortais.</value>
   </data>
   <data name="About_LblInfo5" xml:space="preserve">
@@ -219,19 +219,19 @@ uma xícara de café:</value>
 
 Se o aplicativo for minimizado, ele será restaurado.
 
-Exemplo: se você deseja enviar o VLC para o primeiro plano, use &apos;vlc&apos;.</value>
+Exemplo: se você deseja enviar o VLC para o primeiro plano, use 'vlc'.</value>
   </data>
   <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
     <value>Execute um comando personalizado.
 
-Esses comandos são executados sem elevação especial. Para executar elevado, crie uma tarefa agendada e use &apos;schtasks /Run /TN &quot;TaskName&quot;&apos; como o comando para executar sua tarefa.
+Esses comandos são executados sem elevação especial. Para executar elevado, crie uma tarefa agendada e use 'schtasks /Run /TN "TaskName"' como o comando para executar sua tarefa.
 
-Ou habilite &apos;executar como baixa integridade&apos; para uma execução ainda mais rigorosa.</value>
+Ou habilite 'executar como baixa integridade' para uma execução ainda mais rigorosa.</value>
   </data>
   <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
     <value>Executa o comando através do executor personalizado configurado (em Configuração -&gt; Ferramentas Externas).
 
-Seu comando é fornecido como um argumento &apos;as is&apos;, então você deve fornecer suas próprias cotações, etc., se necessário.</value>
+Seu comando é fornecido como um argumento 'as is', então você deve fornecer suas próprias cotações, etc., se necessário.</value>
   </data>
   <data name="CommandsManager_HibernateCommandDescription" xml:space="preserve">
     <value>Coloca a máquina em hibernação.</value>
@@ -239,15 +239,16 @@ Seu comando é fornecido como um argumento &apos;as is&apos;, então você deve 
   <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
     <value>Simula um único pressionamento de tecla.
 
-Você pode escolher qualquer um destes valores: https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+Clique na caixa de texto 'keycode' e pressione a tecla que deseja simular. O código-chave correspondente será inserido para você.
+Para a tecla TAB, use LCTRL+TAB.
 
-Se você precisar de mais teclas e/ou modificadores como CTRL, use o comando MultipleKeys.</value>
+Se precisar de mais teclas e/ou modificadores como CTRL, use o comando MultipleKeys.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
     <value>Inicia a URL fornecida, por padrão em seu navegador padrão.
 
-Para usar o modo &apos;anônimo&apos;, forneça um navegador específico em Configuração -&gt; Ferramentas Externas.</value>
+Para usar o modo 'anônimo', forneça um navegador específico em Configuração -&gt; Ferramentas Externas.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
@@ -257,28 +258,28 @@ Para usar o modo &apos;anônimo&apos;, forneça um navegador específico em Conf
     <value>Faz logoff da sessão atual.</value>
   </data>
   <data name="CommandsManager_MediaMuteCommandDescription" xml:space="preserve">
-    <value>Simula a tecla &apos;mute&apos;.</value>
+    <value>Simula a tecla 'mute'.</value>
   </data>
   <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
-    <value>Simula a tecla &apos;próxima mídia&apos;.</value>
+    <value>Simula a tecla 'próxima mídia'.</value>
   </data>
   <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
-    <value>Simula a tecla &apos;play/pause mídia&apos;.</value>
+    <value>Simula a tecla 'play/pause mídia'.</value>
   </data>
   <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
-    <value>Simula a tecla &apos;mídia anterior&apos;.</value>
+    <value>Simula a tecla 'mídia anterior'.</value>
   </data>
   <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
-    <value>Simula a tecla &apos;diminuir volume&apos;.</value>
+    <value>Simula a tecla 'diminuir volume'.</value>
   </data>
   <data name="CommandsManager_MediaVolumeUpCommandDescription" xml:space="preserve">
-    <value>Simula a tecla &apos;aumentar o volume&apos;.</value>
+    <value>Simula a tecla 'aumentar o volume'.</value>
   </data>
   <data name="CommandsManager_MonitorSleepCommandDescription" xml:space="preserve">
     <value>Coloca todos os monitores no modo de suspensão (baixo consumo de energia).</value>
   </data>
   <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
-    <value>Tente acordar todos os monitores simulando um pressionamento de tecla &apos;seta para cima&apos;.</value>
+    <value>Tente acordar todos os monitores simulando um pressionamento de tecla 'seta para cima'.</value>
   </data>
   <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
     <value>Simula o pressionamento de várias teclas.
@@ -311,7 +312,7 @@ Isso será executado sem elevação especial.</value>
   <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
     <value>Reinicia a máquina após um minuto.
 
-Dica: acionado acidentalmente? Execute &apos;shutdown /a&apos; para abortar.</value>
+Dica: acionado acidentalmente? Execute 'shutdown /a' para abortar.</value>
   </data>
   <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
     <value>Define o volume do dispositivo de áudio padrão atual para o nível especificado.</value>
@@ -319,7 +320,7 @@ Dica: acionado acidentalmente? Execute &apos;shutdown /a&apos; para abortar.</va
   <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
     <value>Desliga a máquina após um minuto.
 
-Dica: acionado acidentalmente? Execute &apos;shutdown /a&apos; para abortar.</value>
+Dica: acionado acidentalmente? Execute 'shutdown /a' para abortar.</value>
   </data>
   <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
     <value>Coloca a máquina em sleep.
@@ -331,7 +332,7 @@ Você pode usar algo como NirCmd (http://www.nirsoft.net/utils/nircmd.html) para
   <data name="CommandsManager_WebViewCommandDescription" xml:space="preserve">
     <value>Mostra uma janela com a URL fornecida.
 
-Isso difere do comando &apos;LaunchUrl&apos;, pois não carrega um navegador completo, apenas o URL fornecido em sua própria janela.
+Isso difere do comando 'LaunchUrl', pois não carrega um navegador completo, apenas o URL fornecido em sua própria janela.
 
 Você pode usar isso para, por exemplo, mostrar rapidamente o painel do Home Assistant.
 
@@ -356,7 +357,7 @@ Por padrão, ele armazena cookies indefinidamente, então você só precisa faze
     <value>Já existe um comando com esse nome. Você tem certeza que quer continuar?</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox4" xml:space="preserve">
-    <value>Se você não inserir um comando, só poderá usar essa entidade com um valor de &apos;ação&apos; por meio do Home Assistant. Executá-lo como está não fará nada.
+    <value>Se você não inserir um comando, só poderá usar essa entidade com um valor de 'ação' por meio do Home Assistant. Executá-lo como está não fará nada.
 
 Tem certeza de que quer isso?</value>
   </data>
@@ -367,12 +368,12 @@ Tem certeza de que quer isso?</value>
     <value>Falha na verificação das chaves: {0}</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
-    <value>Se você não inserir uma URL, só poderá usar essa entidade com um valor de &apos;ação&apos; por meio do Home Assistant. Executá-lo como está não fará nada.
+    <value>Se você não inserir uma URL, só poderá usar essa entidade com um valor de 'ação' por meio do Home Assistant. Executá-lo como está não fará nada.
 
 Tem certeza de que quer isso?</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
-    <value>Se você não configurar o comando, só poderá usar esta entidade com um valor de &apos;ação&apos; por meio do Home Assistant e ela será exibida usando as configurações padrão. Executar ela como está não fará nada.
+    <value>Se você não configurar o comando, só poderá usar esta entidade com um valor de 'ação' por meio do Home Assistant e ela será exibida usando as configurações padrão. Executar ela como está não fará nada.
 
 Tem certeza que quer isso?</value>
   </data>
@@ -385,7 +386,7 @@ Certifique-se de que o campo de código de acesso esteja em foco e pressione a t
     <value>iniciar no modo de navegação anônima</value>
   </data>
   <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
-    <value>&amp;executar como &apos;baixa integridade&apos;</value>
+    <value>&amp;executar como 'baixa integridade'</value>
   </data>
   <data name="CommandsMod_ClmSensorName" xml:space="preserve">
     <value>tipo</value>
@@ -432,10 +433,10 @@ por favor configure um executor ou seu comando não será executado</value>
     <value>Isso significa que ele só poderá salvar e modificar arquivos em determinados locais,</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
-    <value>como a pasta &apos;%USERPROFILE%\AppData\LocalLow&apos; ou</value>
+    <value>como a pasta '%USERPROFILE%\AppData\LocalLow' ou</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
-    <value>a chave de registro &apos;HKEY_CURRENT_USER\Software\AppDataLow&apos;.</value>
+    <value>a chave de registro 'HKEY_CURRENT_USER\Software\AppDataLow'.</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
     <value>Você deve testar seu comando para garantir que ele não seja influenciado por isso.</value>
@@ -478,12 +479,12 @@ por favor configure um executor ou seu comando não será executado</value>
     <value>hass.agent apenas!</value>
   </data>
   <data name="CommandsMod_MessageBox_Action" xml:space="preserve">
-    <value>Se você não inserir um comando ou script, só poderá usar essa entidade com um valor de &apos;ação&apos; por meio do Home Assistant. Executá-lo como está não fará nada.
+    <value>Se você não inserir um comando ou script, só poderá usar essa entidade com um valor de 'ação' por meio do Home Assistant. Executá-lo como está não fará nada.
 
 Tem certeza de que quer isso?</value>
   </data>
   <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
-    <value>Se você não inserir um valor de volume, só poderá usar essa entidade com um valor de &apos;ação&apos; por meio do Home Assistant. Executá-lo como está não fará nada.
+    <value>Se você não inserir um valor de volume, só poderá usar essa entidade com um valor de 'ação' por meio do Home Assistant. Executá-lo como está não fará nada.
 
 Tem certeza de que quer isso?</value>
   </data>
@@ -643,7 +644,7 @@ os argumentos usados ​​para iniciar em modo privado.</value>
   </data>
   <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
     <value>Você pode configurar o HASS.Agent para usar um executor específico, como perl ou python.
-Use o comando &apos;custom executor&apos; para iniciar este executor.</value>
+Use o comando 'custom executor' para iniciar este executor.</value>
   </data>
   <data name="ConfigExternalTools_LblLaunchIncogArg" xml:space="preserve">
     <value>iniciar incógnito argumento</value>
@@ -718,7 +719,7 @@ Deve conter três seções (separadas por dois pontos).
 Tem certeza de que deseja usá-lo assim?</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox6" xml:space="preserve">
-    <value>Sua URL não parece correta. Deve ser algo como &apos;http://homeassistant.local:8123&apos; ou &apos;http://192.168.0.1:8123&apos;.
+    <value>Sua URL não parece correta. Deve ser algo como 'http://homeassistant.local:8123' ou 'http://192.168.0.1:8123'.
 
 Tem certeza de que deseja usá-la assim?</value>
   </data>
@@ -740,7 +741,7 @@ API do Home Assistant.
 
 Forneça um token de acesso de longa duração e o endereço da sua instância do Home Assistant.
 
-Você pode obter um token através da sua página de perfil. Role até o final e clique em &apos;CRIAR TOKEN&apos;</value>
+Você pode obter um token através da sua página de perfil. Role até o final e clique em 'CRIAR TOKEN'</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigHomeAssistantApi_LblServerUri" xml:space="preserve">
@@ -829,7 +830,7 @@ poderá interagir com o Home Assistant.</value>
   <data name="ConfigLocalStorage_LblInfo1" xml:space="preserve">
     <value>As imagens mostradas nas notificações devem ser armazenadas temporariamente localmente.
 Você pode configurar a quantidade de dias eles devem ser mantidos antes que o HASS.Agent
-os exclua. Digite &apos;0&apos; para mantê-los permanentemente.</value>
+os exclua. Digite '0' para mantê-los permanentemente.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigLocalStorage_LblKeepAudio" xml:space="preserve">
@@ -1037,7 +1038,7 @@ Verifique os logs do HASS.Agent (não do serviço) para obter mais informações
     <value>&amp;começar serviço</value>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
-    <value>O serviço está definido como &apos;desativado&apos;, portanto, não pode ser iniciado.
+    <value>O serviço está definido como 'desativado', portanto, não pode ser iniciado.
 
 Ative o serviço primeiro e tente novamente.</value>
   </data>
@@ -1062,7 +1063,7 @@ Verifique os logs do HASS.Agent (não do serviço) para obter mais informações
   </data>
   <data name="ConfigService_LblInfo1" xml:space="preserve">
     <value>O serviço satélite permite que você execute sensores e comandos mesmo quando nenhum usuário
-estiver conectado. Use o botão &apos;serviço de satélite&apos; na janela principal para gerenciá-lo.</value>
+estiver conectado. Use o botão 'serviço de satélite' na janela principal para gerenciá-lo.</value>
   </data>
   <data name="ConfigService_LblInfo2" xml:space="preserve">
     <value>Se você não configurar o serviço, ele não fará nada. No entanto, você ainda pode decidir desativá-lo 
@@ -1078,7 +1079,7 @@ Sua configuração e entidades não serão removidas.</value>
     <value>Se o serviço ainda falhar após a reinstalação, abra um ticket e envie o conteúdo do log mais recente.</value>
   </data>
   <data name="ConfigService_LblInfo5" xml:space="preserve">
-    <value>Se você deseja gerenciar o serviço (adicionar comandos e sensores, alterar configurações), pode fazê-lo aqui ou usando o botão &apos;serviço satélite&apos; na janela principal.</value>
+    <value>Se você deseja gerenciar o serviço (adicionar comandos e sensores, alterar configurações), pode fazê-lo aqui ou usando o botão 'serviço satélite' na janela principal.</value>
   </data>
   <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
     <value>status do serviço:</value>
@@ -1199,12 +1200,12 @@ Deve conter três seções (separadas por dois pontos).
 Tem certeza de que deseja usá-lo assim?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
-    <value>Sua URL não parece correta. Deve ser algo como &apos;http://homeassistant.local:8123&apos; ou &apos;http://192.168.0.1:8123&apos;.
+    <value>Sua URL não parece correta. Deve ser algo como 'http://homeassistant.local:8123' ou 'http://192.168.0.1:8123'.
 
 Tem certeza de que deseja usá-la assim?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
-    <value>Sua URL do broker MQTT não está correta. Deve ser algo como &apos;homeassistant.local&apos; ou &apos;192.168.0.1&apos;.
+    <value>Sua URL do broker MQTT não está correta. Deve ser algo como 'homeassistant.local' ou '192.168.0.1'.
 
 Tem certeza de que deseja usá-la assim?</value>
   </data>
@@ -1457,10 +1458,10 @@ conosco:</value>
     <value>Ajuda</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
-    <value>Seu idioma de entrada &apos;{0}&apos; é conhecido por colidir com a tecla de atalho CTRL-ALT-Q padrão. Por favor, defina o seu próprio.</value>
+    <value>Seu idioma de entrada '{0}' é conhecido por colidir com a tecla de atalho CTRL-ALT-Q padrão. Por favor, defina o seu próprio.</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
-    <value>Seu idioma de entrada &apos;{0}&apos; é desconhecido e pode colidir com a tecla de atalho CTRL-ALT-Q padrão. Por favor, verifique para ter certeza. Se isso acontecer, considere abrir um ticket no GitHub para que possa ser adicionado à lista.</value>
+    <value>Seu idioma de entrada '{0}' é desconhecido e pode colidir com a tecla de atalho CTRL-ALT-Q padrão. Por favor, verifique para ter certeza. Se isso acontecer, considere abrir um ticket no GitHub para que possa ser adicionado à lista.</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
     <value>nenhuma tecla encontrada</value>
@@ -1472,7 +1473,7 @@ conosco:</value>
     <value>erro ao analisar as teclas, verifique o log para obter mais informações</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
-    <value>o número de colchetes &apos;[&apos; não corresponde aos &apos;]&apos; ({0} a {1})</value>
+    <value>o número de colchetes '[' não corresponde aos ']' ({0} a {1})</value>
   </data>
   <data name="LocalApiManager_Initialize_MessageBox1" xml:space="preserve">
     <value>Certifique-se de que nenhuma outra instância do HASS.Agent esteja em execução e que a porta esteja disponível e registrada.</value>
@@ -1569,7 +1570,7 @@ Nota: esta mensagem é exibida apenas uma vez.</value>
   <data name="Main_Load_MessageBox1" xml:space="preserve">
     <value>Algo deu errado ao carregar suas configurações.
 
-Verifique appsettings.json na subpasta &apos;Config&apos; ou apenas exclua-o para começar de novo.</value>
+Verifique appsettings.json na subpasta 'Config' ou apenas exclua-o para começar de novo.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="Main_Load_MessageBox2" xml:space="preserve">
@@ -1683,7 +1684,7 @@ Deve conter três seções (separadas por dois pontos).
 Tem certeza de que deseja usá-lo assim?</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox6" xml:space="preserve">
-    <value>Sua URL não parece correta. Deve ser algo como &apos;http://homeassistant.local:8123&apos; ou &apos;http://192.168.0.1:8123&apos;.
+    <value>Sua URL não parece correta. Deve ser algo como 'http://homeassistant.local:8123' ou 'http://192.168.0.1:8123'.
 
 Tem certeza de que deseja usá-la assim?</value>
   </data>
@@ -1699,7 +1700,7 @@ HASS.Agent usa API do Home Assistant.
 
 Forneça um token de acesso de longa duração e o endereço da sua instância do Home 
 Assistant. Você pode obter um token através da sua página de perfil. Role até o final e 
-clique em &apos;CRIAR TOKEN&apos;.</value>
+clique em 'CRIAR TOKEN'.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="OnboardingApi_LblServerUri" xml:space="preserve">
@@ -1956,7 +1957,7 @@ O certificado do arquivo baixado será verificado.</value>
   <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
     <value>Parece que esta é a primeira vez que você iniciou o HASS.Agent.
 
-Se você quiser, podemos passar pela configuração. Se não, basta clicar em &apos;fechar&apos;.</value>
+Se você quiser, podemos passar pela configuração. Se não, basta clicar em 'fechar'.</value>
   </data>
   <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
     <value>O nome do dispositivo é usado para identificar sua máquina no HA.
@@ -2165,7 +2166,7 @@ Verifique os logs para obter mais informações e, opcionalmente, informe os des
   <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
     <value>Fornece informações sobre vários aspectos do áudio do seu dispositivo:
 
-Nível de volume de pico atual (pode ser usado como um valor simples de &apos;algo está tocando&apos;).
+Nível de volume de pico atual (pode ser usado como um valor simples de 'algo está tocando').
 
 Dispositivo de áudio padrão: nome, estado e volume.
 
@@ -2209,7 +2210,7 @@ Atualmente leva o volume do seu dispositivo padrão.</value>
 
 Certifique-se de que os serviços de localização do Windows estejam ativados!
 
-Dependendo da sua versão do Windows, isso pode ser encontrado no novo painel de controle -&gt; &apos;privacidade e segurança&apos; -&gt; &apos;localização&apos;.</value>
+Dependendo da sua versão do Windows, isso pode ser encontrado no novo painel de controle -&gt; 'privacidade e segurança' -&gt; 'localização'.</value>
   </data>
   <data name="SensorsManager_GpuLoadSensorDescription" xml:space="preserve">
     <value>Fornece a carga atual da GPU como uma porcentagem.</value>
@@ -2223,7 +2224,7 @@ Dependendo da sua versão do Windows, isso pode ser encontrado no novo painel de
   <data name="SensorsManager_LastBootSensorDescription" xml:space="preserve">
     <value>Fornece um valor de data e hora contendo o último momento em que o sistema (re)inicializou.
 
-Importante: a opção FastBoot do Windows pode prejudicar esse valor, porque é uma forma de hibernação. Você pode desativá-lo através de Opções de energia -&gt; &apos;Escolha o que os botões de energia fazem&apos; -&gt; desmarque &apos;Ativar inicialização rápida&apos;. Não faz muita diferença para máquinas modernas com SSDs, mas desabilitar garante que você obtenha um estado limpo após a reinicialização.</value>
+Importante: a opção FastBoot do Windows pode prejudicar esse valor, porque é uma forma de hibernação. Você pode desativá-lo através de Opções de energia -&gt; 'Escolha o que os botões de energia fazem' -&gt; desmarque 'Ativar inicialização rápida'. Não faz muita diferença para máquinas modernas com SSDs, mas desabilitar garante que você obtenha um estado limpo após a reinicialização.</value>
   </data>
   <data name="SensorsManager_LastSystemStateChangeSensorDescription" xml:space="preserve">
     <value>Fornece a última alteração de estado do sistema:
@@ -2273,7 +2274,7 @@ Categoria: Processador
 Contador: % de tempo do processador
 Instância: _Total
 
-Você pode explorar os contadores através da ferramenta &apos;perfmon.exe&apos; do Windows.</value>
+Você pode explorar os contadores através da ferramenta 'perfmon.exe' do Windows.</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
     <value>Retorna o resultado do comando ou script do Powershell fornecido.
@@ -2290,7 +2291,7 @@ Converte o resultado em texto.</value>
   <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
     <value>Retorna o estado do serviço fornecido: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending ou Paused.
 
-Certifique-se de fornecer o &apos;Nome do serviço&apos;, não o &apos;Nome de exibição&apos;.</value>
+Certifique-se de fornecer o 'Nome do serviço', não o 'Nome de exibição'.</value>
   </data>
   <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
     <value>Fornece o estado da sessão atual:
@@ -2810,7 +2811,7 @@ Deixe em branco para permitir que todos se conectem.</value>
   <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
     <value>Este é o nome com o qual o serviço satélite se registra no Home Assistant.
 
-Por padrão, é o nome do seu PC mais &apos;-satellite&apos;.</value>
+Por padrão, é o nome do seu PC mais '-satellite'.</value>
   </data>
   <data name="ServiceGeneral_LblDisconGrace" xml:space="preserve">
     <value>&amp;período de desconexão</value>
@@ -2822,7 +2823,7 @@ Por padrão, é o nome do seu PC mais &apos;-satellite&apos;.</value>
     <value>Esta página contém itens de configuração geral. Para configurações, sensores e comandos do MQTT, navegue nas guias na parte superior.</value>
   </data>
   <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
-    <value>Você pode usar o serviço satélite para executar sensores e comandos sem precisar estar logado. Nem todos os tipos estão disponíveis, por exemplo, o comando &apos;Iniciar Url&apos; só pode ser adicionado como um comando regular.</value>
+    <value>Você pode usar o serviço satélite para executar sensores e comandos sem precisar estar logado. Nem todos os tipos estão disponíveis, por exemplo, o comando 'Iniciar Url' só pode ser adicionado como um comando regular.</value>
   </data>
   <data name="ServiceGeneral_LblSeconds" xml:space="preserve">
     <value>segundos</value>
@@ -3240,7 +3241,7 @@ Deseja baixar o Microsoft WebView2 runtime?</value>
     <value>tamanho</value>
   </data>
   <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
-    <value>dica: pressione &apos;esc&apos; para fechar uma visualização da web</value>
+    <value>dica: pressione 'esc' para fechar uma visualização da web</value>
   </data>
   <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
     <value>&amp;URL</value>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.resx
@@ -363,6 +363,7 @@ Your command is provided as an argument 'as is', so you have to supply your own 
     <value>Simulates a single keypress.
 
 Click on the 'keycode' textbox and press the key you want simulated. The corresponding keycode will be entered for you.
+For TAB key please use LCTRL+TAB.
 
 If you need more keys and/or modifiers like CTRL, use the MultipleKeys command.</value>
   </data>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.ru.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.ru.resx
@@ -139,7 +139,7 @@
   </data>
   <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
     <value>Вы можете настроить HASS.Agent для использования определенного исполнителя, например perl или python.
-Используйте команду &apos;пользовательский исполнитель&apos;, чтобы запустить этот исполнитель.</value>
+Используйте команду 'пользовательский исполнитель', чтобы запустить этот исполнитель.</value>
   </data>
   <data name="ConfigExternalTools_LblCustomExecutorName" xml:space="preserve">
     <value>пользовательское имя исполнителя</value>
@@ -198,7 +198,7 @@ API домашнего помощника.
 
 Пожалуйста, предоставьте токен доступа с длительным сроком действия и адрес вашего экземпляра Home Assistant.
 
-Вы можете получить токен через страницу своего профиля. Прокрутите страницу вниз и нажмите &apos;СОЗДАТЬ ТОКЕН&apos;.</value>
+Вы можете получить токен через страницу своего профиля. Прокрутите страницу вниз и нажмите 'СОЗДАТЬ ТОКЕН'.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
@@ -241,7 +241,7 @@ API домашнего помощника.
     <value>Некоторые элементы, например изображения, отображаемые в уведомлениях, должны временно храниться локально. Вы можете
 настроить количество дней, в течение которых они должны храниться до того как HASS.Агент удаляет их.
 
-Введите &apos;0&apos;, чтобы сохранить их навсегда.</value>
+Введите '0', чтобы сохранить их навсегда.</value>
   </data>
   <data name="ConfigLogging_LblInfo1" xml:space="preserve">
     <value>Расширенное ведение журнала обеспечивает более подробное ведение журнала в случае, если ведение журнала по умолчанию недостаточно
@@ -342,7 +342,7 @@ API домашнего помощника.
   </data>
   <data name="ConfigService_LblInfo1" xml:space="preserve">
     <value>Спутниковая служба позволяет запускать датчики и команды, даже если ни один пользователь не вошел в систему.
-Используйте кнопку &apos;спутниковая служба&apos; в главном окне, чтобы управлять ею.</value>
+Используйте кнопку 'спутниковая служба' в главном окне, чтобы управлять ею.</value>
   </data>
   <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
     <value>статус сервиса:</value>
@@ -416,7 +416,7 @@ HASS.Agent там.</value>
   <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
     <value>Похоже это первый раз, когда вы запустили HASS.Agent.
 
-Если вы хотите, мы можем просмотреть конфигурацию. Если нет, просто нажмите кнопку &apos;закрыть&apos;.
+Если вы хотите, мы можем просмотреть конфигурацию. Если нет, просто нажмите кнопку 'закрыть'.
 </value>
   </data>
   <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
@@ -476,10 +476,10 @@ Home Assistant.
   </data>
   <data name="OnboardingApi_LblInfo1" xml:space="preserve">
     <value>Чтобы узнать, какие объекты вы настроили, и отправить быстрые действия, HASS.Agent использует
-Home Assistant&apos;s API.
+Home Assistant's API.
 
 Пожалуйста, предоставьте токен доступа с длительным сроком действия и адрес вашего экземпляра Home Assistant.
-Вы можете получить токен через страницу своего профиля.Прокрутите страницу вниз и нажмите &apos;СОЗДАТЬ ТОКЕН&apos;.</value>
+Вы можете получить токен через страницу своего профиля.Прокрутите страницу вниз и нажмите 'СОЗДАТЬ ТОКЕН'.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="OnboardingApi_BtnTest" xml:space="preserve">
@@ -848,7 +848,7 @@ HASS.Agent для прослушивания на указанном порту.
     <value>описание</value>
   </data>
   <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
-    <value>&amp;запускать как &apos;low integrity&apos;</value>
+    <value>&amp;запускать как 'low integrity'</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
     <value>что это?</value>
@@ -1049,7 +1049,7 @@ HASS.Agent для прослушивания на указанном порту.
 проекта используемых компонентов на предмет их индивидуальных лицензий:</value>
   </data>
   <data name="About_LblInfo4" xml:space="preserve">
-    <value>Большое &apos;спасибо&apos; разработчикам этих проектов, которые были достаточно любезны, чтобы поделиться
+    <value>Большое 'спасибо' разработчикам этих проектов, которые были достаточно любезны, чтобы поделиться
 своей тяжелой работой с остальными из нас, простых смертных. </value>
   </data>
   <data name="About_LblInfo5" xml:space="preserve">
@@ -1276,14 +1276,14 @@ HASS.Agent для прослушивания на указанном порту.
   <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
     <value>Выполните пользовательскую команду.
 
-Эти команды выполняются без специального разрешения. Для запуска с повышенными правами создайте запланированную задачу и используйте &apos;schtasks /Run /TN &quot;TaskName&quot;&apos; в качестве команды для выполнения вашей задачи.
+Эти команды выполняются без специального разрешения. Для запуска с повышенными правами создайте запланированную задачу и используйте 'schtasks /Run /TN "TaskName"' в качестве команды для выполнения вашей задачи.
 
-Или включите &apos;run as low integrity&apos; для еще более строгого выполнения.</value>
+Или включите 'run as low integrity' для еще более строгого выполнения.</value>
   </data>
   <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
     <value>Выполняет команду через настроенный пользовательский исполнитель (в разделе Конфигурация -&gt; Внешние инструменты).
 
-Ваша команда предоставляется в качестве аргумента &apos;как есть&apos;, поэтому при необходимости вы должны указать свои собственные кавычки и т.д.</value>
+Ваша команда предоставляется в качестве аргумента 'как есть', поэтому при необходимости вы должны указать свои собственные кавычки и т.д.</value>
   </data>
   <data name="CommandsManager_HibernateCommandDescription" xml:space="preserve">
     <value>Переводит машину в режим гибернации.</value>
@@ -1291,17 +1291,18 @@ HASS.Agent для прослушивания на указанном порту.
   <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
     <value>Имитирует одно нажатие клавиши.
 
-Нажмите на текстовое поле &apos;код ключа&apos; и нажмите клавишу, которую вы хотите смоделировать. Для вас будет введен соответствующий код ключа.
+Нажмите на текстовое поле «keycode» и нажмите клавишу, которую вы хотите имитировать. Соответствующий ключевой код будет введен для вас.
+Для клавиши TAB используйте LCTRL+TAB.
 
-Если вам нужно больше клавиш и/или модификаторов, таких как CTRL, используйте команду Multiple Keys.</value>
+Если вам нужно больше клавиш и/или модификаторов, таких как CTRL, используйте команду MultipleKeys.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
     <value>Запускает указанный URL-адрес по умолчанию в вашем браузере по умолчанию.
 
-Чтобы использовать &apos;инкогнито&apos;, укажите конкретный браузер в разделе Конфигурация -&gt; Внешние инструменты.
+Чтобы использовать 'инкогнито', укажите конкретный браузер в разделе Конфигурация -&gt; Внешние инструменты.
 
-Если вам нужно просто окно с определенным URL-адресом (а не весь браузер целиком), используйте команду &apos;WebView&apos;.</value>
+Если вам нужно просто окно с определенным URL-адресом (а не весь браузер целиком), используйте команду 'WebView'.</value>
   </data>
   <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
     <value>Блокировать текущий сеанс.</value>
@@ -1313,13 +1314,13 @@ HASS.Agent для прослушивания на указанном порту.
     <value>Имитирует клавишу отключения звука.</value>
   </data>
   <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
-    <value>Имитирует клавишу &apos;media next&apos;.</value>
+    <value>Имитирует клавишу 'media next'.</value>
   </data>
   <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
-    <value>Имитирует клавишу &apos;media playpause&apos;.</value>
+    <value>Имитирует клавишу 'media playpause'.</value>
   </data>
   <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
-    <value>Имитирует клавишу &apos;media previous&apos;.</value>
+    <value>Имитирует клавишу 'media previous'.</value>
   </data>
   <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
     <value>Имитирует клавишу уменьшения громкости.</value>
@@ -1359,12 +1360,12 @@ HASS.Agent для прослушивания на указанном порту.
   <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
     <value>Перезапускает машину через одну минуту.
 
-Совет: случайно сработало? Запустите &apos;shutdown /a&apos;, чтобы прервать работу.</value>
+Совет: случайно сработало? Запустите 'shutdown /a', чтобы прервать работу.</value>
   </data>
   <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
     <value>Выключает машину через одну минуту.
 
-Совет: случайно сработало? Запустите &apos;shutdown /a&apos;, чтобы прервать работу.</value>
+Совет: случайно сработало? Запустите 'shutdown /a', чтобы прервать работу.</value>
   </data>
   <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
     <value>Переводит машину в спящий режим.
@@ -1393,7 +1394,7 @@ HASS.Agent для прослушивания на указанном порту.
     <value>Пожалуйста, введите действительный ключ API.</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox2" xml:space="preserve">
-    <value>Пожалуйста, введите ваш Home Assistant&apos;s URI.</value>
+    <value>Пожалуйста, введите ваш Home Assistant's URI.</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox3" xml:space="preserve">
     <value>Не удалось подключиться, была возвращена следующая ошибка:
@@ -1453,7 +1454,7 @@ Home Assistant version: {0}</value>
 Проверь HASS.Agent (не службы) логи для получения дополнительной информации.</value>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
-    <value>Для службы установлено значение &apos;отключено&apos;, поэтому ее нельзя запустить.
+    <value>Для службы установлено значение 'отключено', поэтому ее нельзя запустить.
 
 Пожалуйста, сначала включите службу, а затем повторите попытку.</value>
   </data>
@@ -1512,7 +1513,7 @@ Home Assistant version: {0}</value>
     <value>активируя запуск при входе в систему, подождите ..</value>
   </data>
   <data name="OnboardingStartup_Failed" xml:space="preserve">
-    <value>Что-то пошло не так. Вы можете попробовать еще раз или перейти к следующей странице и повторить попытку после перезагрузки HASS.Agent&apos;s.</value>
+    <value>Что-то пошло не так. Вы можете попробовать еще раз или перейти к следующей странице и повторить попытку после перезагрузки HASS.Agent's.</value>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin_2" xml:space="preserve">
     <value>включить запуск при входе в систему</value>
@@ -1629,7 +1630,7 @@ Home Assistant version: {0}</value>
   <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
     <value>Это имя, под которым спутниковая служба регистрируется в Home Assistant.
 
-По умолчанию это имя вашего КОМПЬЮТЕРА плюс &apos;-satellite&apos;.</value>
+По умолчанию это имя вашего КОМПЬЮТЕРА плюс '-satellite'.</value>
   </data>
   <data name="ServiceGeneral_LblDisconGraceInfo_MessageBox1" xml:space="preserve">
     <value>Количество времени, в течение которого спутниковая служба будет ждать, прежде чем сообщить о потере соединения брокеру MQTT.</value>
@@ -1711,12 +1712,12 @@ Home Assistant version: {0}</value>
     <value>Команда с таким именем уже существует. Вы уверены, что хотите продолжить?</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox4" xml:space="preserve">
-    <value>Если вы не вводите команду, вы можете использовать эту сущность только со значением &apos;действие&apos; через Home Assistant. Запуск его как есть ничего не даст.
+    <value>Если вы не вводите команду, вы можете использовать эту сущность только со значением 'действие' через Home Assistant. Запуск его как есть ничего не даст.
 
 Ты уверен, что хочешь этого?</value>
   </data>
   <data name="CommandsMod_MessageBox_Action" xml:space="preserve">
-    <value>Если вы не вводите команду или сценарий, вы можете использовать эту сущность только со значением &apos;действие&apos; через Home Assistant. Запуск его как есть ничего не даст.
+    <value>Если вы не вводите команду или сценарий, вы можете использовать эту сущность только со значением 'действие' через Home Assistant. Запуск его как есть ничего не даст.
 
 Ты уверен, что хочешь этого?</value>
   </data>
@@ -1727,7 +1728,7 @@ Home Assistant version: {0}</value>
     <value>Проверка клавиш не удалась: {0}</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
-    <value>Если вы не вводите URL-адрес, вы можете использовать этот объект только со значением &apos;действие&apos; через Home Assistant. Запуск его как есть ничего не даст.
+    <value>Если вы не вводите URL-адрес, вы можете использовать этот объект только со значением 'действие' через Home Assistant. Запуск его как есть ничего не даст.
 
 Ты уверен, что хочешь этого?</value>
   </data>
@@ -1773,10 +1774,10 @@ Home Assistant version: {0}</value>
     <value>Это означает, что он сможет сохранять и изменять файлы только в определенных местах,</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
-    <value>например, в папке &apos;%USERPROFILE%\AppData\LocalLow&apos; или</value>
+    <value>например, в папке '%USERPROFILE%\AppData\LocalLow' или</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
-    <value>раздел реестра &apos;HKEY_CURRENT_USER\Software\AppDataLow&apos;.</value>
+    <value>раздел реестра 'HKEY_CURRENT_USER\Software\AppDataLow'.</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
     <value>Вы должны протестировать свою команду, чтобы убедиться, что это не повлияет на нее.</value>
@@ -1894,7 +1895,7 @@ Home Assistant version: {0}</value>
 
 Не волнуйтесь, они сохранят свои текущие имена, так что ваши средства автоматизации или скрипты будут продолжать работать.
 
-Примечание: имя будет &apos;очищено&apos;, что означает, что все, кроме букв, цифр и пробелов, будет заменено символом подчеркивания. Этого требует HA.</value>
+Примечание: имя будет 'очищено', что означает, что все, кроме букв, цифр и пробелов, будет заменено символом подчеркивания. Этого требует HA.</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox2" xml:space="preserve">
     <value>Вы изменили порт локального API. Этот новый порт должен быть зарезервирован.
@@ -1926,7 +1927,7 @@ Home Assistant version: {0}</value>
   <data name="Main_Load_MessageBox1" xml:space="preserve">
     <value>Что-то пошло не так при загрузке ваших настроек.
 
-Проверьте appsettings.json во вложенной папке &apos;config&apos; или просто удалите его, чтобы начать все сначала.</value>
+Проверьте appsettings.json во вложенной папке 'config' или просто удалите его, чтобы начать все сначала.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="Main_Load_MessageBox2" xml:space="preserve">
@@ -2082,7 +2083,7 @@ Home Assistant version: {0}</value>
   <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
     <value>Предоставляет информацию о различных аспектах звука вашего устройства:
 
-Текущий пиковый уровень громкости (может использоваться как простое значение &apos;что-то играет&apos;).
+Текущий пиковый уровень громкости (может использоваться как простое значение 'что-то играет').
 
 Аудиоустройство по умолчанию: имя, состояние и громкость.
 
@@ -2121,7 +2122,7 @@ Home Assistant version: {0}</value>
   <data name="SensorsManager_LastBootSensorDescription" xml:space="preserve">
     <value>Предоставляет значение даты и времени, содержащее последний момент (повторной) загрузки системы.
 
-Важно: опция быстрой загрузки Windows может сбросить это значение, потому что это форма гибернации. Вы можете отключить его через Параметры питания -&gt; &apos;Выберите, что делают кнопки питания&apos; -&gt; снимите флажок &apos;Включить быстрый запуск&apos;. Это не имеет большого значения для современных машин с твердотельными накопителями, но отключение гарантирует, что вы получите чистое состояние после перезагрузки.</value>
+Важно: опция быстрой загрузки Windows может сбросить это значение, потому что это форма гибернации. Вы можете отключить его через Параметры питания -&gt; 'Выберите, что делают кнопки питания' -&gt; снимите флажок 'Включить быстрый запуск'. Это не имеет большого значения для современных машин с твердотельными накопителями, но отключение гарантирует, что вы получите чистое состояние после перезагрузки.</value>
   </data>
   <data name="SensorsManager_LastSystemStateChangeSensorDescription" xml:space="preserve">
     <value>Обеспечивает последнее изменение состояния системы:
@@ -2163,7 +2164,7 @@ Category: Processor
 Counter: % Processor Time
 Instance: _Total
 
-Вы можете исследовать счетчики через Windows&apos; &apos;perfmon.exe&apos; - инструмент.</value>
+Вы можете исследовать счетчики через Windows' 'perfmon.exe' - инструмент.</value>
   </data>
   <data name="SensorsManager_ProcessActiveSensorDescription" xml:space="preserve">
     <value>Указывает количество активных экземпляров процесса.</value>
@@ -2172,7 +2173,7 @@ Instance: _Total
   <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
     <value>Возвращает состояние предоставленной службы: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending or Paused.
 
-Обязательно укажите &apos;Имя службы&apos;, а не &apos;Display name&apos;.</value>
+Обязательно укажите 'Имя службы', а не 'Display name'.</value>
   </data>
   <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
     <value>Предоставляет текущее состояние сеанса:
@@ -2652,7 +2653,7 @@ NotPresent, Busy, RunningDirect3dFullScreen, PresentationMode, AcceptsNotificati
     <value>ApplicationStarted</value>
   </data>
   <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
-    <value>Вы можете использовать спутниковую службу для запуска датчиков и команд без необходимости входа в систему. Доступны не все типы, например, команда &apos;launchUrl&apos; может быть добавлена только как обычная команда.</value>
+    <value>Вы можете использовать спутниковую службу для запуска датчиков и команд без необходимости входа в систему. Доступны не все типы, например, команда 'launchUrl' может быть добавлена только как обычная команда.</value>
   </data>
   <data name="SensorsConfig_ClmValue" xml:space="preserve">
     <value>последнее известное значение</value>
@@ -2685,10 +2686,10 @@ NotPresent, Busy, RunningDirect3dFullScreen, PresentationMode, AcceptsNotificati
 
 Если приложение свернуто, оно будет восстановлено.
 
-Пример: если вы хотите отправить VLC на передний план, используйте &apos;vlc&apos;.</value>
+Пример: если вы хотите отправить VLC на передний план, используйте 'vlc'.</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
-    <value>Если вы не настроили команду, вы можете использовать эту сущность только со значением &apos;действие&apos; через Home Assistant, и она будет отображаться с использованием настроек по умолчанию. Запуск его как есть ничего не даст.
+    <value>Если вы не настроили команду, вы можете использовать эту сущность только со значением 'действие' через Home Assistant, и она будет отображаться с использованием настроек по умолчанию. Запуск его как есть ничего не даст.
 
 Ты уверен, что хочешь этого? </value>
   </data>
@@ -2828,10 +2829,10 @@ NotPresent, Busy, RunningDirect3dFullScreen, PresentationMode, AcceptsNotificati
     <value>Значок в трее</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
-    <value>Известно, что ваш язык ввода &apos;{0}&apos; конфликтует с горячей клавишей CTRL-ALT-Q по умолчанию. Пожалуйста, установите свой собственный.</value>
+    <value>Известно, что ваш язык ввода '{0}' конфликтует с горячей клавишей CTRL-ALT-Q по умолчанию. Пожалуйста, установите свой собственный.</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
-    <value>Ваш язык ввода &apos;{0}&apos; неизвестен и может конфликтовать с горячей клавишей CTRL-ALT-Q по умолчанию. Пожалуйста, проверьте, чтобы быть уверенным. Если это произойдет, рассмотрите возможность открытия заявки на GitHub, чтобы ее можно было добавить в список.</value>
+    <value>Ваш язык ввода '{0}' неизвестен и может конфликтовать с горячей клавишей CTRL-ALT-Q по умолчанию. Пожалуйста, проверьте, чтобы быть уверенным. Если это произойдет, рассмотрите возможность открытия заявки на GitHub, чтобы ее можно было добавить в список.</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
     <value>клавиши не найдены</value>
@@ -2843,7 +2844,7 @@ NotPresent, Busy, RunningDirect3dFullScreen, PresentationMode, AcceptsNotificati
     <value>ошибка при разборе клавиш, проверьте журнал для получения дополнительной информации</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
-    <value>количество скобок &apos;[&apos; не соответствует скобкам &apos;]&apos; (от {0} до {1})</value>
+    <value>количество скобок '[' не соответствует скобкам ']' (от {0} до {1})</value>
   </data>
   <data name="Help_LblDocumentation" xml:space="preserve">
     <value>Документация</value>
@@ -2947,7 +2948,7 @@ Home Assistant.
     <value>размер</value>
   </data>
   <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
-    <value>совет: нажмите клавишу &apos;esc&apos;, чтобы закрыть веб-просмотр</value>
+    <value>совет: нажмите клавишу 'esc', чтобы закрыть веб-просмотр</value>
   </data>
   <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
     <value>&amp;URL</value>
@@ -3054,7 +3055,7 @@ Home Assistant.
     <value>Command</value>
   </data>
   <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
-    <value>Если вы не вводите значение громкости, вы можете использовать этот объект только со значением &quot;действие&quot; через Home Assistant. Запуск его как есть ничего не даст.
+    <value>Если вы не вводите значение громкости, вы можете использовать этот объект только со значением "действие" через Home Assistant. Запуск его как есть ничего не даст.
 
 Ты уверен, что хочешь этого?</value>
   </data>
@@ -3101,7 +3102,7 @@ Home Assistant.
 Пожалуйста, сначала запустите службу, чтобы настроить ее.</value>
   </data>
   <data name="ConfigService_LblInfo5" xml:space="preserve">
-    <value>Если вы хотите управлять сервисом (добавьте команды и датчики, измените настройки), вы можете сделать это здесь или с помощью кнопки &apos;спутниковая служба&apos; в главном окне.</value>
+    <value>Если вы хотите управлять сервисом (добавьте команды и датчики, измените настройки), вы можете сделать это здесь или с помощью кнопки 'спутниковая служба' в главном окне.</value>
   </data>
   <data name="ConfigTrayIcon_CbWebViewShowMenuOnLeftClick" xml:space="preserve">
     <value>Показать меню по умолчанию при щелчке левой кнопкой мыши</value>
@@ -3113,12 +3114,12 @@ Home Assistant.
 Вы уверены, что хотите использовать его именно так?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
-    <value>Ваш  Home Assistant URI выглядит неправильно. Это должно выглядеть примерно так &apos;http://homeassistant.local:8123&apos; или &apos;https://192.168.0.1:8123&apos;.
+    <value>Ваш  Home Assistant URI выглядит неправильно. Это должно выглядеть примерно так 'http://homeassistant.local:8123' или 'https://192.168.0.1:8123'.
 
 Вы уверены, что хотите использовать его именно так?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
-    <value>Ваш URI брокера MQTT выглядит неправильно. Это должно выглядеть примерно как &apos;homeassistant.local&apos; или &apos;192.168.0.1&apos;.
+    <value>Ваш URI брокера MQTT выглядит неправильно. Это должно выглядеть примерно как 'homeassistant.local' или '192.168.0.1'.
 
 Вы уверены, что хотите использовать его именно так?</value>
   </data>
@@ -3160,7 +3161,7 @@ Home Assistant.
     <value>Разработка и обслуживание этого инструмента (и всего, что его окружает) отнимает много времени. Как и большинство разработчиков, я работаю на кофеине - так что, если вы можете поделиться им, чашка кофе всегда очень ценится!</value>
   </data>
   <data name="OnboardingDone_LblTip2" xml:space="preserve">
-    <value>Совет: Другие способы пожертвования доступны в окне &apos;О программе&apos;.</value>
+    <value>Совет: Другие способы пожертвования доступны в окне 'О программе'.</value>
   </data>
   <data name="OnboardingIntegrations_CbEnableMediaPlayer" xml:space="preserve">
     <value>Включить &amp;медиаплеер (включая преобразование текста в речь)</value>
@@ -3191,7 +3192,7 @@ Home Assistant.
 
 Убедитесь, что службы определения местоположения Windows включены!
 
-В зависимости от вашей версии Windows, это можно найти в новой панели управления -&gt; &apos;конфиденциальность и безопасность&apos; -&gt; &apos;местоположение&apos;.</value>
+В зависимости от вашей версии Windows, это можно найти в новой панели управления -&gt; 'конфиденциальность и безопасность' -&gt; 'местоположение'.</value>
   </data>
   <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
     <value>Указывает имя процесса, который в данный момент использует микрофон.

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.sl.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.sl.resx
@@ -132,7 +132,7 @@
 uporabljenih komponentah za njihove posamezne licence:</value>
   </data>
   <data name="About_LblInfo4" xml:space="preserve">
-    <value>Velika &apos;hvala&apos; razvijalcem teh projektov, ki so bili dovolj prijazni, da so jih delili
+    <value>Velika 'hvala' razvijalcem teh projektov, ki so bili dovolj prijazni, da so jih delili
 njihovo trdo delo z nami, navadnimi smrtniki. </value>
   </data>
   <data name="About_LblInfo5" xml:space="preserve">
@@ -225,27 +225,28 @@ je ustvarila in vzdržujte Home Assistant :-)</value>
 
 Če je aplikacija minimirana jo poveča.
 
-Primer: če želite v ospredje poslati VLC uporabite &apos;vlc&apos;</value>
+Primer: če želite v ospredje poslati VLC uporabite 'vlc'</value>
   </data>
   <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
     <value>Izvedite ukaz po meri.
 
-Ti ukazi se izvajajo brez posebnih pravic. Če želite zagnati z večjimi pravicami, ustvarite načrtovano opravilo in uporabite &apos;schtasks /Run /TN &quot;TaskName&quot;&apos; kot ukaz za izvedbo vaše naloge.
+Ti ukazi se izvajajo brez posebnih pravic. Če želite zagnati z večjimi pravicami, ustvarite načrtovano opravilo in uporabite 'schtasks /Run /TN "TaskName"' kot ukaz za izvedbo vaše naloge.
 
-Ali pa omogočite &apos;zaženi z nizko integriteto&apos; za še strožjo izvedbo.</value>
+Ali pa omogočite 'zaženi z nizko integriteto' za še strožjo izvedbo.</value>
   </data>
   <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
     <value>Izvede ukaz prek konfiguriranega izvajalca po meri (v Konfiguracija -&gt; Zunanja orodja).
 
-Vaš ukaz je podan kot argument &apos;tako kot je&apos;, zato morate po potrebi navesti svoje narekovaje itd.</value>
+Vaš ukaz je podan kot argument 'tako kot je', zato morate po potrebi navesti svoje narekovaje itd.</value>
   </data>
   <data name="CommandsManager_HibernateCommandDescription" xml:space="preserve">
     <value>Preklopi napravo v stanje mirovanja.</value>
   </data>
   <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
-    <value>Simulira en sam pritisk na tipko.
+    <value>Simulira en sam pritisk tipke.
 
-Kliknite na &apos;keycode&apos; in pritisnite tipko, ki jo želite simulirati. Koda tipke bo avtomatično vpisana.
+Kliknite besedilno polje 'keycode' in pritisnite tipko, ki jo želite simulirati. Vnesena bo ustrezna koda tipke.
+Za tipko TAB uporabite LCTRL+TAB.
 
 Če potrebujete več tipk in/ali modifikatorjev, kot je CTRL, uporabite ukaz MultipleKeys.</value>
     <comment>Fuzzy</comment>
@@ -253,9 +254,9 @@ Kliknite na &apos;keycode&apos; in pritisnite tipko, ki jo želite simulirati. K
   <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
     <value>Zažene navedeni URL, privzeto v privzetem brskalniku.
 
-Če želite uporabljati &apos;brez beleženja zgodovine&apos;, navedite določen brskalnik v Konfiguracija -&gt; Zunanja orodja.
+Če želite uporabljati 'brez beleženja zgodovine', navedite določen brskalnik v Konfiguracija -&gt; Zunanja orodja.
 
-Če želite samo okno z določenim URL (ne cel brskalnik) uporabite ukaz &apos;WebView&apos;.</value>
+Če želite samo okno z določenim URL (ne cel brskalnik) uporabite ukaz 'WebView'.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
@@ -268,10 +269,10 @@ Kliknite na &apos;keycode&apos; in pritisnite tipko, ki jo želite simulirati. K
     <value>Simulira tipko za izklop zvoka.</value>
   </data>
   <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
-    <value>Simulira tipko &apos;media next&apos;.</value>
+    <value>Simulira tipko 'media next'.</value>
   </data>
   <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
-    <value>Simulira tipko &apos;media playpause&apos;.</value>
+    <value>Simulira tipko 'media playpause'.</value>
   </data>
   <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
     <value>Simulira tipko »prejšnji mediji«.</value>
@@ -286,7 +287,7 @@ Kliknite na &apos;keycode&apos; in pritisnite tipko, ki jo želite simulirati. K
     <value>Nastavi vse monitorje na spanje (low power).</value>
   </data>
   <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
-    <value>Poskusi zbuditi vse monitorje tako, da simulira pritisk tipke &apos;gor&apos;.</value>
+    <value>Poskusi zbuditi vse monitorje tako, da simulira pritisk tipke 'gor'.</value>
   </data>
   <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
     <value>Simulira pritiskanje več tipk.
@@ -319,7 +320,7 @@ Uporabno na primer, če želite prisiliti HASS.Agent, da posodobi vse vaše senz
   <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
     <value>Po eni minuti znova zažene napravo.
 
-Nasvet: slučajno sprožen? Zaženite &apos;shutdown /a&apos; za prekinitev.</value>
+Nasvet: slučajno sprožen? Zaženite 'shutdown /a' za prekinitev.</value>
   </data>
   <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
     <value>Nastavi glasnost trenutno privzete avdio naprave na nastavljeno vrednost.</value>
@@ -327,7 +328,7 @@ Nasvet: slučajno sprožen? Zaženite &apos;shutdown /a&apos; za prekinitev.</va
   <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
     <value>Po eni minuti izklopi napravo.
 
-Nasvet: slučajno sprožen? Zaženite &apos;shutdown /a&apos; za prekinitev.</value>
+Nasvet: slučajno sprožen? Zaženite 'shutdown /a' za prekinitev.</value>
   </data>
   <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
     <value>Preklopi napravo v stanje spanja.
@@ -339,7 +340,7 @@ Lahko uporabite nekaj, kot je NirCmd (http://www.nirsoft.net/utils/nircmd.html),
   <data name="CommandsManager_WebViewCommandDescription" xml:space="preserve">
     <value>Prikaže okno z vpisanim URL.
 
-Tole se razlikuje od ukaza &apos;LaunchUrl&apos; tkao, da se ne naloži v polnem brskalniku, ampak samo naveden URL v svojem oknu.
+Tole se razlikuje od ukaza 'LaunchUrl' tkao, da se ne naloži v polnem brskalniku, ampak samo naveden URL v svojem oknu.
 
 To lahko uporabite npr. za hitri prikaz glavnega okna Home Assistant.
 
@@ -376,12 +377,12 @@ Ste prepričani, da želite to?</value>
     <value>Preverjanje ključev ni uspelo: {0}</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
-    <value>Če ne vnesete URL-ja, lahko to entiteto uporabite samo z vrednostjo &apos;action&apos; prek Home Assistant. Če ga zaženete kot je, ne boste naredili ničesar.
+    <value>Če ne vnesete URL-ja, lahko to entiteto uporabite samo z vrednostjo 'action' prek Home Assistant. Če ga zaženete kot je, ne boste naredili ničesar.
 
 Ste prepričani, da želite to?</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
-    <value>Če ukaza ne skonfigurirate ga lahko uporabite samo kot &apos;akcija&apos; preko Home Assistant, prikazana pa bo samo privzeta vrednost. Zagon &apos;kot je&apos; ne bo naredil ničesar.
+    <value>Če ukaza ne skonfigurirate ga lahko uporabite samo kot 'akcija' preko Home Assistant, prikazana pa bo samo privzeta vrednost. Zagon 'kot je' ne bo naredil ničesar.
 
 Ali ste prepričani, da želite to?</value>
   </data>
@@ -394,7 +395,7 @@ Prepričajte se, da je polje kode tipke v fokusu, nato pritisnite tipko, ki jo �
     <value>zagon v načinu brez beleženja zgodovine</value>
   </data>
   <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
-    <value>&amp;zaženi kot &apos;nizka integriteta&apos;</value>
+    <value>&amp;zaženi kot 'nizka integriteta'</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="CommandsMod_ClmSensorName" xml:space="preserve">
@@ -443,10 +444,10 @@ prosimo, konfigurirajte izvajalca, sicer se vaš ukaz ne bo zagnal</value>
     <value>To pomeni, da bo lahko shranil in spreminjal datoteke samo na določenih lokacijah,</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
-    <value>kot je mapa &apos;%USERPROFILE%\AppData\LocalLow&apos; oz</value>
+    <value>kot je mapa '%USERPROFILE%\AppData\LocalLow' oz</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
-    <value>registrski ključ &apos;HKEY_CURRENT_USER\Software\AppDataLow&apos;.</value>
+    <value>registrski ključ 'HKEY_CURRENT_USER\Software\AppDataLow'.</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
     <value>Preizkusite svoj ukaz, da se prepričate, da to ne vpliva nanj.</value>
@@ -496,7 +497,7 @@ prosimo, konfigurirajte izvajalca, sicer se vaš ukaz ne bo zagnal</value>
 Ste prepričani, da želite to?</value>
   </data>
   <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
-    <value>Če ne vpišete vrednosti za glasnost boste to entiteto lahko uporabljali samo kot &apos;akcijsko&apos; vrednost preko Home Assistant-a. Zagon &apos;tako, kot je&apos; ne bo naredil ničesar.
+    <value>Če ne vpišete vrednosti za glasnost boste to entiteto lahko uporabljali samo kot 'akcijsko' vrednost preko Home Assistant-a. Zagon 'tako, kot je' ne bo naredil ničesar.
 
 Ali ste prepričani v to?</value>
   </data>
@@ -657,7 +658,7 @@ Dodatno lahko nastaviš tudi argumente za zagon v privatnem načinu.</value>
   </data>
   <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
     <value>HASS.Agent lahko konfigurirate za uporabo določenega izvajalca, kot sta perl ali python.
-Za zagon tega izvajalca uporabite ukaz &apos;custom executor&apos;.</value>
+Za zagon tega izvajalca uporabite ukaz 'custom executor'.</value>
   </data>
   <data name="ConfigExternalTools_LblLaunchIncogArg" xml:space="preserve">
     <value>argumenti za privatni način</value>
@@ -735,7 +736,7 @@ Različica Home Assistant: {0}</value>
 Ali ste prepričani, da ga želite uporabiti takole?</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox6" xml:space="preserve">
-    <value>Vaš URI naslov ne izgleda v redu. Izgledati bi moral nekako takole: &apos;http://homeassistant.local:8123&apos; or &apos;http://192.168.0.1:8123&apos;.
+    <value>Vaš URI naslov ne izgleda v redu. Izgledati bi moral nekako takole: 'http://homeassistant.local:8123' or 'http://192.168.0.1:8123'.
 
 Ali ste prepričani, da ga želite uporabiti takole?</value>
   </data>
@@ -760,7 +761,7 @@ API Home Assistant.
 
 Navedite dolgotrajni žeton za dostop in naslov svojega primerka Home Assistant.
 
-Žeton lahko dobite na strani vašega profila. Pomaknite se do dna in kliknite &apos;USTVARI ŽETON&apos;.</value>
+Žeton lahko dobite na strani vašega profila. Pomaknite se do dna in kliknite 'USTVARI ŽETON'.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigHomeAssistantApi_LblServerUri" xml:space="preserve">
@@ -855,7 +856,7 @@ Opomba: za delovanje nove integracije to ni nujno. Omogočite in uporabljajte ga
     <value>Slike, prikazane v obvestilih, je treba začasno shraniti lokalno. Konfigurirate lahko koliko
 dni jih je treba hraniti, preden jih HASS.Agent izbriše. 
 
-Vnesite &apos;0&apos;, da jih obdržite za vedno.</value>
+Vnesite '0', da jih obdržite za vedno.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigLocalStorage_LblKeepAudio" xml:space="preserve">
@@ -1081,7 +1082,7 @@ Za več informacij preverite dnevnike HASS.Agent (ne storitve).</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
-    <value>Storitev je nastavljena na &apos;onemogočena&apos;, zato je ni mogoče zagnati.
+    <value>Storitev je nastavljena na 'onemogočena', zato je ni mogoče zagnati.
 
 Najprej omogočite storitev, nato poskusite znova.</value>
   </data>
@@ -1107,7 +1108,7 @@ Za več informacij preverite dnevnike HASS.Agent (ne storitve).</value>
   </data>
   <data name="ConfigService_LblInfo1" xml:space="preserve">
     <value>Satelitski servis omogoča izvajanje senzorjev in komand tudi, ko ni nihče prijavljen.
-Uporabi gumb &apos;Satelitski servis&apos; v glavnem meniju za upravljanje.</value>
+Uporabi gumb 'Satelitski servis' v glavnem meniju za upravljanje.</value>
   </data>
   <data name="ConfigService_LblInfo2" xml:space="preserve">
     <value>Če servisa ne nastaviš, ne bo naredil ničesar. Če želiš, ga lahko še vedno samo onemogočiš.
@@ -1122,7 +1123,7 @@ Konfiguracija in entitete ne bodo odstranjene.</value>
     <value>Če storitev po ponovni namestitvi še vedno ne uspe, odprite vstopnico in pošljite vsebino najnovejšega dnevnika.</value>
   </data>
   <data name="ConfigService_LblInfo5" xml:space="preserve">
-    <value>Če želite upravljati storitev (dodajanje ukazov, senzorjev, spremembe) lahko to storite tukaj, ali pa z uporabo gumba &apos;satelitska storitev&apos; v glavnem oknu.</value>
+    <value>Če želite upravljati storitev (dodajanje ukazov, senzorjev, spremembe) lahko to storite tukaj, ali pa z uporabo gumba 'satelitska storitev' v glavnem oknu.</value>
   </data>
   <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
     <value>stanje servisa:</value>
@@ -1249,12 +1250,12 @@ Vsebovati mora tri sekcije (ločene s pikami).
 Ali ste prepričani, da ga želite uporabiti takole?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
-    <value>Vaša povezava do Home Assistant-a ne izgleda v redu. Morala bi biti nekako takole: &apos;http://homeassistant.local:8123&apos; ali &apos;https://192.168.0.1:8123&apos;.
+    <value>Vaša povezava do Home Assistant-a ne izgleda v redu. Morala bi biti nekako takole: 'http://homeassistant.local:8123' ali 'https://192.168.0.1:8123'.
 
 Ali ste prepričani, da jo želite uporabiti takole?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
-    <value>Vaša povezava do MQTT strežnika ne izgleda v redu. Morala bi biti nekako takole: &apos;homeassistant.local&apos; ali &apos;192.168.0.1&apos;.
+    <value>Vaša povezava do MQTT strežnika ne izgleda v redu. Morala bi biti nekako takole: 'homeassistant.local' ali '192.168.0.1'.
 
 Ali ste prepričani, da jo želite uporabiti takole?</value>
   </data>
@@ -1270,7 +1271,7 @@ se bo nato znova zagnal, da jih bo znova objavil.
 
 Ne skrbite, ohranili bodo svoja trenutna imena, tako da bodo vaše avtomatizacije ali skripti normalno delovali.
 
-Opomba: ime se bo &apos;očistilo&apos;, kar pomeni, da bo vse, razen črk, številk in presledkov nadomeščeno s podčrtajem. To je zahteva Home Assistant.</value>
+Opomba: ime se bo 'očistilo', kar pomeni, da bo vse, razen črk, številk in presledkov nadomeščeno s podčrtajem. To je zahteva Home Assistant.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox2" xml:space="preserve">
@@ -1511,10 +1512,10 @@ Obstaja nekaj kanalov, preko katerih nas lahko dosežete:</value>
     <value>Pomoč</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
-    <value>Vaš vhodni jezik &apos;{0}&apos; je znan, da je v konfliktu s privzeto bližnjivo CTRL-ALT-Q. Prosim, nastavite svojo.</value>
+    <value>Vaš vhodni jezik '{0}' je znan, da je v konfliktu s privzeto bližnjivo CTRL-ALT-Q. Prosim, nastavite svojo.</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
-    <value>Vaš vhodni jezik &apos;{0}&apos;  je neznan in je lahko v konfliktu s privzeto bližnjivo CTRL-ALT-Q. Prosim, preverite. Če je v konfliktu odprite pomoč v GitHub, da bo dodan na seznam.</value>
+    <value>Vaš vhodni jezik '{0}'  je neznan in je lahko v konfliktu s privzeto bližnjivo CTRL-ALT-Q. Prosim, preverite. Če je v konfliktu odprite pomoč v GitHub, da bo dodan na seznam.</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
     <value>Ni najdenih ključev</value>
@@ -1526,7 +1527,7 @@ Obstaja nekaj kanalov, preko katerih nas lahko dosežete:</value>
     <value>napaka pri razčlenjevanju ključev, glejte dnevnik</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
-    <value>število oklepajev &apos;[&apos; ne ustreza številu oklepajev  &apos;]&apos;  ({0} do {1})</value>
+    <value>število oklepajev '[' ne ustreza številu oklepajev  ']'  ({0} do {1})</value>
   </data>
   <data name="LocalApiManager_Initialize_MessageBox1" xml:space="preserve">
     <value>Napaka pri povezovanju API z vrati {0}.
@@ -1626,7 +1627,7 @@ Opomba: to sporočilo bo prikazano samo enkrat.</value>
   <data name="Main_Load_MessageBox1" xml:space="preserve">
     <value>Pri nalaganju nastavitev je šlo nekaj narobe.
 
-Preverite appsettings.json v podmapi &apos;Config&apos; ali jo preprosto izbrišite, da začnete znova.</value>
+Preverite appsettings.json v podmapi 'Config' ali jo preprosto izbrišite, da začnete znova.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="Main_Load_MessageBox2" xml:space="preserve">
@@ -1744,7 +1745,7 @@ Vsebovati mora tri sekcije (ločene s pikami).
 Ali ste prepričani, da ga želite uporabiti takole?</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox6" xml:space="preserve">
-    <value>Vaša povezava ne izgleda v redu. Morala bi biti nekako takole: &apos;http://homeassistant.local:8123&apos; ali &apos;https://192.168.0.1:8123&apos;.
+    <value>Vaša povezava ne izgleda v redu. Morala bi biti nekako takole: 'http://homeassistant.local:8123' ali 'https://192.168.0.1:8123'.
 
 Ali ste prepričani, da jo želite uporabiti takole?</value>
   </data>
@@ -1760,7 +1761,7 @@ Ali ste prepričani, da jo želite uporabiti takole?</value>
 API Home Assistant.
 
 Navedite dolgotrajni žeton za dostop in naslov svojega primerka Home Assistant.
-Žeton lahko dobite na strani profila. Pomaknite se do dna in kliknite &apos;USTVARI ŽETEN&apos;.</value>
+Žeton lahko dobite na strani profila. Pomaknite se do dna in kliknite 'USTVARI ŽETEN'.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="OnboardingApi_LblServerUri" xml:space="preserve">
@@ -1791,7 +1792,7 @@ Hvala, ker uporabljate HASS.Agent. Upam, da vam bo koristil :-)</value>
     <value>Razvoj in vzdrževanje tega dodatka (in vsega, kar spada zraven, kot je podpora, navodila) vzame veliko časa. Kot večina razvijalcev tudi jaz delam na kofein - zato bi bil zelo hvaležen kake skodelice kave, če jo lahko pogrešate!</value>
   </data>
   <data name="OnboardingDone_LblTip2" xml:space="preserve">
-    <value>Namig: ostale možnosti donacij so na voljo v zavihku &quot;Vizitka&quot;.</value>
+    <value>Namig: ostale možnosti donacij so na voljo v zavihku "Vizitka".</value>
   </data>
   <data name="OnboardingHotKey_BtnClear" xml:space="preserve">
     <value>počisti</value>
@@ -2016,7 +2017,7 @@ Potrdilo prenesene datoteke bo preverjeno. Še vedno boste videli stran z izdaja
   <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
     <value>Izgleda, da je to tvoj prvi zagon HASS.Agenta.
 
-Če želiš, lahko greva čez nastavitve. Če ne, samo pritisni &apos;zapri&apos;.
+Če želiš, lahko greva čez nastavitve. Če ne, samo pritisni 'zapri'.
 </value>
   </data>
   <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
@@ -2242,7 +2243,7 @@ Preverite dnevnike za več informacij in po želji obvestite razvijalce.</value>
   <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
     <value>Zagotavlja informacije o različnih vidikih zvoka vaše naprave:
 
-Trenutna najvišja raven glasnosti (lahko se uporabi kot preprosta vrednost &apos;is something playing&apos;).
+Trenutna najvišja raven glasnosti (lahko se uporabi kot preprosta vrednost 'is something playing').
 
 Privzeta zvočna naprava: ime, stanje in glasnost.
 
@@ -2350,7 +2351,7 @@ Kategorija: Procesor
 Števec: % procesorskega časa
 Primer: _Skupaj
 
-Številke lahko raziščete z orodjem Windows &apos;perfmon.exe&apos;.</value>
+Številke lahko raziščete z orodjem Windows 'perfmon.exe'.</value>
   </data>
   <data name="SensorsManager_PowershellSensorDescription" xml:space="preserve">
     <value>Vrne rezultat Powershell ukaza ali skripta.
@@ -2367,7 +2368,7 @@ Pretvori rezultat v tekst.</value>
   <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
     <value>Vrne stanje zagotovljene storitve: NotFound, Stopped, StartPending, StopPending, Running, ContinuePending, PausePending ali Paused.
 
-Prepričajte se, da ste navedli &apos;Service name&apos;, ne pa &apos;Display name&apos;.</value>
+Prepričajte se, da ste navedli 'Service name', ne pa 'Display name'.</value>
   </data>
   <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
     <value>Zagotavlja trenutno stanje seje:
@@ -2393,7 +2394,7 @@ Lahko se na primer uporablja za določanje, ali želite poslati obvestila ali sp
   <data name="SensorsManager_WebcamProcessSensorDescription" xml:space="preserve">
     <value>Vrne ime procesa, ki trenutno uporablja kamero.
 
-Opomba: če jo uporablja satelitska storitev, potem &apos;userspace&apos; aplikacije ne bodo zaznane.</value>
+Opomba: če jo uporablja satelitska storitev, potem 'userspace' aplikacije ne bodo zaznane.</value>
   </data>
   <data name="SensorsManager_WindowStateSensorDescription" xml:space="preserve">
     <value>Vrne trenutno stanje okna procesa:
@@ -2900,7 +2901,7 @@ Pustite prazno, da se vsi povežejo.</value>
   <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
     <value>To je ime, s katerim se satelitska storitev registrira v Home Assistant.
 
-Privzeto je to ime vašega računalnika in &apos;-satellite&apos;.</value>
+Privzeto je to ime vašega računalnika in '-satellite'.</value>
   </data>
   <data name="ServiceGeneral_LblDisconGrace" xml:space="preserve">
     <value>prekinjena milostna doba</value>
@@ -2913,7 +2914,7 @@ Privzeto je to ime vašega računalnika in &apos;-satellite&apos;.</value>
     <value>Ta stran vsebuje splošne konfiguracijske elemente. Za nastavitve, senzorje in ukaze MQTT brskajte po zavihkih na vrhu.</value>
   </data>
   <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
-    <value>Lahko uporabite satelitsko storitev za senzorje in ukaze brez, da ste prijavljeni. Vsi tipi niso na voljo, npr. &apos;LaunchUrl&apos; ukaz se lahko doda samo kot klasičen ukaz.</value>
+    <value>Lahko uporabite satelitsko storitev za senzorje in ukaze brez, da ste prijavljeni. Vsi tipi niso na voljo, npr. 'LaunchUrl' ukaz se lahko doda samo kot klasičen ukaz.</value>
   </data>
   <data name="ServiceGeneral_LblSeconds" xml:space="preserve">
     <value>sekundah</value>
@@ -3315,7 +3316,7 @@ Namesto tega se bo odprla stran za izdajo.</value>
 Ali želite prenesti runtime installer?</value>
   </data>
   <data name="WebView_InitializeAsync_MessageBox2" xml:space="preserve">
-    <value>Nekaj je šlo narobe pri inicializaciji WebView. Preverite dnevnike in odprite GitHub &apos;ticket&apos; za pomoč.</value>
+    <value>Nekaj je šlo narobe pri inicializaciji WebView. Preverite dnevnike in odprite GitHub 'ticket' za pomoč.</value>
   </data>
   <data name="WebView_Title" xml:space="preserve">
     <value>WebView</value>
@@ -3342,7 +3343,7 @@ Ali želite prenesti runtime installer?</value>
     <value>velikost</value>
   </data>
   <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
-    <value>namig: pritisni &apos;esc&apos; da zapreš webview</value>
+    <value>namig: pritisni 'esc' da zapreš webview</value>
   </data>
   <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
     <value>&amp;URL</value>

--- a/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.tr.resx
+++ b/src/HASS.Agent.Staging/HASS.Agent/Resources/Localization/Languages.tr.resx
@@ -124,7 +124,7 @@
     <value>Tarayıcı adı</value>
   </data>
   <data name="ConfigExternalTools_LblInfo2" xml:space="preserve">
-    <value>Varsayılan olarak HASS.Agent, varsayılan tarayıcınızı kullanarak URL&apos;leri başlatır. 
+    <value>Varsayılan olarak HASS.Agent, varsayılan tarayıcınızı kullanarak URL'leri başlatır. 
 Ayrıca, 
 özel modda çalışacak başlatma argümanlarıyla birlikte kullanılacak belirli bir tarayıcıyı da yapılandırabilirsiniz.</value>
     <comment>Fuzzy</comment>
@@ -139,8 +139,8 @@ Ayrıca,
     <value>Özel Yürütücü İkili Dosyası</value>
   </data>
   <data name="ConfigExternalTools_LblInfo3" xml:space="preserve">
-    <value>HASS.Agent&apos;ı Perl veya Python gibi belirli bir yorumlayıcı kullanacak şekilde yapılandırabilirsiniz.
-Bu yürütücüyü başlatmak için &apos;özel yürütücü&apos; komutunu kullanın.</value>
+    <value>HASS.Agent'ı Perl veya Python gibi belirli bir yorumlayıcı kullanacak şekilde yapılandırabilirsiniz.
+Bu yürütücüyü başlatmak için 'özel yürütücü' komutunu kullanın.</value>
   </data>
   <data name="ConfigExternalTools_LblCustomExecutorName" xml:space="preserve">
     <value>Özel Yürütücü Adı</value>
@@ -152,7 +152,7 @@ Bu yürütücüyü başlatmak için &apos;özel yürütücü&apos; komutunu kull
     <value>&amp;Ölçek</value>
   </data>
   <data name="ConfigGeneral_LblInfo4" xml:space="preserve">
-    <value>HASS.Agent, MQTT veya HA&apos;nın API&apos;si ile olan bağlantı kesintilerini size bildirmeden önce bir ek süre bekleyecektir. 
+    <value>HASS.Agent, MQTT veya HA'nın API'si ile olan bağlantı kesintilerini size bildirmeden önce bir ek süre bekleyecektir. 
 Aşağıda bu ek süre içinde beklenecek saniye miktarını ayarlayabilirsiniz.</value>
   </data>
   <data name="ConfigGeneral_LblDisconGraceSeconds" xml:space="preserve">
@@ -166,7 +166,7 @@ Aşağıda bu ek süre içinde beklenecek saniye miktarını ayarlayabilirsiniz.
 Otomasyonlarınız ve komut dosyalarınız çalışmaya devam edecek.</value>
   </data>
   <data name="ConfigGeneral_LblInfo2" xml:space="preserve">
-    <value>Cihaz adı, Home Assistant&apos;ta makinenizi tanımlamak için kullanılır. Ayrıca komut/sensör adlarınız için bir önek olarak kullanılır (bu, varlık başına değiştirilebilir).</value>
+    <value>Cihaz adı, Home Assistant'ta makinenizi tanımlamak için kullanılır. Ayrıca komut/sensör adlarınız için bir önek olarak kullanılır (bu, varlık başına değiştirilebilir).</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="ConfigGeneral_LblInfo1" xml:space="preserve">
@@ -189,11 +189,11 @@ Otomasyonlarınız ve komut dosyalarınız çalışmaya devam edecek.</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblInfo1" xml:space="preserve">
     <value>Hangi varlıkları yapılandırdığınızı öğrenmek ve hızlı eylemler göndermek için HASS.Agent, 
-Home Assistant&apos;ın API&apos;sini kullanır. 
+Home Assistant'ın API'sini kullanır. 
 
 Lütfen uzun ömürlü bir erişim belirteci ve Home Assistant örneğinizin adresini sağlayın. 
-Home Assistant&apos;ta sol alttaki profil resminize tıklayarak 
-ve &apos;TOKEN OLUŞTUR&apos; düğmesini görene kadar sayfanın en altına giderek bir token alabilirsiniz.</value>
+Home Assistant'ta sol alttaki profil resminize tıklayarak 
+ve 'TOKEN OLUŞTUR' düğmesini görene kadar sayfanın en altına giderek bir token alabilirsiniz.</value>
   </data>
   <data name="ConfigHomeAssistantApi_LblApiToken" xml:space="preserve">
     <value>&amp;API Simgesi</value>
@@ -231,12 +231,12 @@ Bu şekilde, makinenizde ne yapıyorsanız yapın, Home Assistant ile her zaman 
     <value>Bildirimlerde gösterilen resimler gibi bazı öğelerin geçici olarak yerel olarak depolanması gerekir. HASS.Agent 
 bunları silmeden önce tutulması gereken gün miktarını yapılandırabilirsiniz. 
 
-Bunları kalıcı olarak tutmak için &apos;0&apos; girin.</value>
+Bunları kalıcı olarak tutmak için '0' girin.</value>
   </data>
   <data name="ConfigLogging_LblInfo1" xml:space="preserve">
     <value>Genişletilmiş günlük kaydı, varsayılan günlük kaydının yeterli olmaması durumunda daha ayrıntılı ve derinlemesine günlük 
 kaydı sağlar. Lütfen bunun etkinleştirilmesinin günlük dosyalarının büyümesine neden olabileceğini 
-ve yalnızca HASS.Agent&apos;ın kendisinde bir sorun olduğundan şüphelendiğinizde veya 
+ve yalnızca HASS.Agent'ın kendisinde bir sorun olduğundan şüphelendiğinizde veya 
 geliştiriciler tarafından istendiğinde kullanılması gerektiğini unutmayın.</value>
   </data>
   <data name="ConfigLogging_CbExtendedLogging" xml:space="preserve">
@@ -267,7 +267,7 @@ geliştiriciler tarafından istendiğinde kullanılması gerektiğini unutmayın
     <value>(emin değilseniz varsayılanı bırakın)</value>
   </data>
   <data name="ConfigMqtt_LblInfo1" xml:space="preserve">
-    <value>Komutlar ve sensörler, yeni entegrasyonu kullanırken bildirimler ve medya oynatıcı işlevlerinin yanı sıra MQTT&apos;yi kullanır. 
+    <value>Komutlar ve sensörler, yeni entegrasyonu kullanırken bildirimler ve medya oynatıcı işlevlerinin yanı sıra MQTT'yi kullanır. 
 
 Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini kullanıyorsanız, muhtemelen önceden ayarlanmış adresi kullanabilirsiniz.
 
@@ -295,10 +295,10 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Müşteri Kimliği</value>
   </data>
   <data name="ConfigNotifications_LblInfo2" xml:space="preserve">
-    <value>Bir şey çalışmıyorsa, aşağıdaki adımları denediğinizden emin olun: - HASS.Agent entegrasyonunu kurun - Home Assistant&apos;ı yeniden başlatın - MQTT etkinken HASS.Agent&apos;ın etkin olduğundan emin olun! - Cihazınız otomatik olarak bir varlık olarak algılanmalı ve eklenmelidir - İsteğe bağlı olarak: yerel API&apos;yi kullanarak manuel olarak ekleyin</value>
+    <value>Bir şey çalışmıyorsa, aşağıdaki adımları denediğinizden emin olun: - HASS.Agent entegrasyonunu kurun - Home Assistant'ı yeniden başlatın - MQTT etkinken HASS.Agent'ın etkin olduğundan emin olun! - Cihazınız otomatik olarak bir varlık olarak algılanmalı ve eklenmelidir - İsteğe bağlı olarak: yerel API'yi kullanarak manuel olarak ekleyin</value>
   </data>
   <data name="ConfigNotifications_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent metin, resim ve eylemleri kullanarak Home Assistant&apos;tan bildirimler alabilir. MQTT&apos;yi etkinleştirdiyseniz, cihazınız otomatik olarak eklenir. Aksi takdirde, yerel API&apos;yi kullanmak için entegrasyonu manuel olarak yapılandırın.</value>
+    <value>HASS.Agent metin, resim ve eylemleri kullanarak Home Assistant'tan bildirimler alabilir. MQTT'yi etkinleştirdiyseniz, cihazınız otomatik olarak eklenir. Aksi takdirde, yerel API'yi kullanmak için entegrasyonu manuel olarak yapılandırın.</value>
   </data>
   <data name="ConfigNotifications_BtnNotificationsReadme" xml:space="preserve">
     <value>Bildirimler ve Belgeler</value>
@@ -319,7 +319,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>&amp;Görüntüler için sertifika hatalarını yoksay</value>
   </data>
   <data name="ConfigService_LblInfo1" xml:space="preserve">
-    <value>Uydu hizmeti, hiçbir kullanıcı oturum açmadığında bile sensörleri ve komutları çalıştırmanıza izin verir. Yönetmek için ana penceredeki &apos;uydu hizmeti&apos; düğmesini kullanın.</value>
+    <value>Uydu hizmeti, hiçbir kullanıcı oturum açmadığında bile sensörleri ve komutları çalıştırmanıza izin verir. Yönetmek için ana penceredeki 'uydu hizmeti' düğmesini kullanın.</value>
   </data>
   <data name="ConfigService_LblServiceStatusInfo" xml:space="preserve">
     <value>Servis durumu:</value>
@@ -352,7 +352,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Yeniden yüklemeden sonra hizmet hala başarısız olursa, lütfen bir bilet açın ve en son günlüğün içeriğini gönderin.</value>
   </data>
   <data name="ConfigStartup_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent, kullanıcı profilinizin kayıt defterinde bir giriş oluşturarak oturum açtığınızda başlayabilir. HASS.Agent kullanıcı tabanlı olduğundan, başka bir kullanıcı için başlatmak istiyorsanız, HASS.Agent&apos;ı orada kurun ve yapılandırın.</value>
+    <value>HASS.Agent, kullanıcı profilinizin kayıt defterinde bir giriş oluşturarak oturum açtığınızda başlayabilir. HASS.Agent kullanıcı tabanlı olduğundan, başka bir kullanıcı için başlatmak istiyorsanız, HASS.Agent'ı orada kurun ve yapılandırın.</value>
   </data>
   <data name="ConfigStartup_BtnSetStartOnLogin" xml:space="preserve">
     <value>&amp;Oturum Açıldığında Başlatmayı Etkinleştir</value>
@@ -376,16 +376,16 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Yeni bir &amp;sürüm çıktığında bana haber ver</value>
   </data>
   <data name="OnboardingWelcome_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent&apos;a hoş geldiniz! Aracıyı ilk kez başlatıyorsunuz gibi görünüyor. İlk kurulumda size yardımcı olmak için aşağıdaki yapılandırma adımlarını uygulayın veya alternatif olarak &apos;Kapat&apos;ı tıklayın.</value>
+    <value>HASS.Agent'a hoş geldiniz! Aracıyı ilk kez başlatıyorsunuz gibi görünüyor. İlk kurulumda size yardımcı olmak için aşağıdaki yapılandırma adımlarını uygulayın veya alternatif olarak 'Kapat'ı tıklayın.</value>
   </data>
   <data name="OnboardingWelcome_LblInfo2" xml:space="preserve">
-    <value>Cihaz adı, Home Assistant&apos;ta makinenizi tanımlamak için kullanılır, ayrıca komutlarınız ve sensörleriniz için önerilen bir önek olarak kullanılır.</value>
+    <value>Cihaz adı, Home Assistant'ta makinenizi tanımlamak için kullanılır, ayrıca komutlarınız ve sensörleriniz için önerilen bir önek olarak kullanılır.</value>
   </data>
   <data name="OnboardingWelcome_LblDeviceName" xml:space="preserve">
     <value>Cihaz adı</value>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin" xml:space="preserve">
-    <value>Evet, Sistem Girişinde HASS.Agent&apos;ı &amp;başlatın</value>
+    <value>Evet, Sistem Girişinde HASS.Agent'ı &amp;başlatın</value>
   </data>
   <data name="OnboardingStartup_LblInfo1" xml:space="preserve">
     <value>HASS.Agent, sisteminizle başlayabilir, bu, oturum açar açmaz cihazınız ve Home Assistant arasındaki tüm sensörlerin ve veri aktarımının başlamasına olanak tanır. Bu ayar, daha sonra HASS.Agent yapılandırma penceresinde herhangi bir zamanda değiştirilebilir.</value>
@@ -394,22 +394,22 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Mevcut durum getiriliyor, lütfen bekleyin..</value>
   </data>
   <data name="OnboardingNotifications_LblTip1" xml:space="preserve">
-    <value>Not: 5115 varsayılan bağlantı noktasıdır, yalnızca Home Assistant&apos;ta değiştirdiyseniz değiştirin.</value>
+    <value>Not: 5115 varsayılan bağlantı noktasıdır, yalnızca Home Assistant'ta değiştirdiyseniz değiştirin.</value>
   </data>
   <data name="OnboardingNotifications_CbAcceptNotifications" xml:space="preserve">
     <value>Evet, bağlantı noktasındaki bildirimleri kabul et</value>
   </data>
   <data name="OnboardingNotifications_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent, metin ve/veya resimler kullanarak Home Assistant&apos;tan bildirimler alabilir. Bu işlevi etkinleştirmek istiyor musunuz?</value>
+    <value>HASS.Agent, metin ve/veya resimler kullanarak Home Assistant'tan bildirimler alabilir. Bu işlevi etkinleştirmek istiyor musunuz?</value>
   </data>
   <data name="OnboardingIntegration_LblIntegration" xml:space="preserve">
     <value>HASS.Agent-Notifier GitHub Sayfası</value>
   </data>
   <data name="OnboardingIntegration_LblInfo2" xml:space="preserve">
-    <value>Şu adımları uyguladığınızdan emin olun: - HASS.Agent-Notifier entegrasyonunu kurun - Home Assistant&apos;ı yeniden başlatın - Bir bildirim varlığı yapılandırın - Home Assistant&apos;ı yeniden başlatın</value>
+    <value>Şu adımları uyguladığınızdan emin olun: - HASS.Agent-Notifier entegrasyonunu kurun - Home Assistant'ı yeniden başlatın - Bir bildirim varlığı yapılandırın - Home Assistant'ı yeniden başlatın</value>
   </data>
   <data name="OnboardingIntegration_LblInfo1" xml:space="preserve">
-    <value>Bildirimleri kullanmak için Home Assistant&apos;ta HASS.Agent-notifier entegrasyonunu kurmanız ve yapılandırmanız gerekir. Bu, HACS&apos;yi kullanmak çok kolaydır, ancak manuel olarak da kurulabilir, daha fazla bilgi için aşağıdaki bağlantıyı ziyaret edin.</value>
+    <value>Bildirimleri kullanmak için Home Assistant'ta HASS.Agent-notifier entegrasyonunu kurmanız ve yapılandırmanız gerekir. Bu, HACS'yi kullanmak çok kolaydır, ancak manuel olarak da kurulabilir, daha fazla bilgi için aşağıdaki bağlantıyı ziyaret edin.</value>
   </data>
   <data name="OnboardingApi_LblApiToken" xml:space="preserve">
     <value>API &amp; Jeton</value>
@@ -418,7 +418,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Sunucu &amp;URI (böyle olması gerekir)</value>
   </data>
   <data name="OnboardingApi_LblInfo1" xml:space="preserve">
-    <value>Hangi varlıkları yapılandırdığınızı öğrenmek ve hızlı eylemler göndermek için HASS.Agent, Home Assistant&apos;ın API&apos;sini kullanır. Lütfen uzun ömürlü bir erişim belirteci ve Home Assistant örneğinizin adresini sağlayın. Home Assistant&apos;ta sol alttaki profil resminize tıklayarak ve &apos;TOKEN OLUŞTUR&apos; düğmesini görene kadar sayfanın en altına giderek bir jeton alabilirsiniz.</value>
+    <value>Hangi varlıkları yapılandırdığınızı öğrenmek ve hızlı eylemler göndermek için HASS.Agent, Home Assistant'ın API'sini kullanır. Lütfen uzun ömürlü bir erişim belirteci ve Home Assistant örneğinizin adresini sağlayın. Home Assistant'ta sol alttaki profil resminize tıklayarak ve 'TOKEN OLUŞTUR' düğmesini görene kadar sayfanın en altına giderek bir jeton alabilirsiniz.</value>
   </data>
   <data name="OnboardingApi_BtnTest" xml:space="preserve">
     <value>Test bağlantısı</value>
@@ -475,7 +475,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>HASS.Agent GitHub sayfası</value>
   </data>
   <data name="OnboardingDone_LblInfo3" xml:space="preserve">
-    <value> Kurcalanacak daha çok şey var, bu yüzden Yapılandırma Penceresine bir göz attığınızdan emin olun! HASS.Agent&apos;ı kullandığınız için teşekkür ederiz, umarım işinize yarar :-)</value>
+    <value> Kurcalanacak daha çok şey var, bu yüzden Yapılandırma Penceresine bir göz attığınızdan emin olun! HASS.Agent'ı kullandığınız için teşekkür ederiz, umarım işinize yarar :-)</value>
   </data>
   <data name="OnboardingDone_LblInfo2" xml:space="preserve">
     <value>HASS.Agent şimdi yapılandırma değişikliklerinizi uygulamak için yeniden başlatılacak.</value>
@@ -610,7 +610,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>&amp;Gönder &amp;&amp; Yapılandırmayı Etkinleştir</value>
   </data>
   <data name="ServiceMqtt_BtnCopy" xml:space="preserve">
-    <value>&amp;HASS.Agent&apos;tan kopyala</value>
+    <value>&amp;HASS.Agent'tan kopyala</value>
   </data>
   <data name="ServiceMqtt_LblStored" xml:space="preserve">
     <value>Yapılandırma kaydedildi!</value>
@@ -676,7 +676,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Önceki örneğin kapanması bekleniyor..</value>
   </data>
   <data name="Restart_LblTask2" xml:space="preserve">
-    <value>HASS.Agent&apos;ı Yeniden Başlatın</value>
+    <value>HASS.Agent'ı Yeniden Başlatın</value>
   </data>
   <data name="Restart_Title" xml:space="preserve">
     <value>HASS.Agent Yeniden Başlatıcı</value>
@@ -757,7 +757,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Tanım</value>
   </data>
   <data name="CommandsMod_CbRunAsLowIntegrity" xml:space="preserve">
-    <value>&amp;&apos;Düşük Bütünlük&apos; olarak çalıştır</value>
+    <value>&amp;'Düşük Bütünlük' olarak çalıştır</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo" xml:space="preserve">
     <value>Bu nedir?</value>
@@ -957,7 +957,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Bu uygulama açık kaynak kodlu ve tamamen ücretsizdir, lütfen kullanılan bileşenlerin proje sayfalarını bireysel lisansları için kontrol edin:</value>
   </data>
   <data name="About_LblInfo4" xml:space="preserve">
-    <value> Sıkı çalışmalarını biz fanilerle paylaşma nezaketini gösteren bu projelerin geliştiricilerine büyük bir &apos;teşekkür ederim&apos;.</value>
+    <value> Sıkı çalışmalarını biz fanilerle paylaşma nezaketini gösteren bu projelerin geliştiricilerine büyük bir 'teşekkür ederim'.</value>
   </data>
   <data name="About_LblInfo5" xml:space="preserve">
     <value>Ve tabi ki; Paulus Shoutsen ve Home Assistant :-) yaratan ve bakımını yapan tüm geliştirici ekibine teşekkürler</value>
@@ -978,7 +978,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Harici Araçlar</value>
   </data>
   <data name="Configuration_TabHassApi" xml:space="preserve">
-    <value>Ev Yardımcısı API&apos;sı</value>
+    <value>Ev Yardımcısı API'sı</value>
   </data>
   <data name="Configuration_TabHotKey" xml:space="preserve">
     <value>Kısayol tuşu</value>
@@ -1056,7 +1056,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Hataları bildirin, özellik istekleri gönderin, en son değişiklikleri görün vb.</value>
   </data>
   <data name="Help_LblDiscordInfo" xml:space="preserve">
-    <value>HASS.Agent&apos;ı kurma ve kullanma konusunda yardım alın, hataları bildirin veya genel sohbete katılın!</value>
+    <value>HASS.Agent'ı kurma ve kullanma konusunda yardım alın, hataları bildirin veya genel sohbete katılın!</value>
   </data>
   <data name="Help_LblWikiInfo" xml:space="preserve">
     <value>HASS.Agent belgelerine ve kullanım örneklerine göz atın.</value>
@@ -1065,7 +1065,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Yardım</value>
   </data>
   <data name="Main_TsShow" xml:space="preserve">
-    <value>HASS.Agent&apos;ı göster</value>
+    <value>HASS.Agent'ı göster</value>
   </data>
   <data name="Main_TsShowQuickActions" xml:space="preserve">
     <value>Hızlı İşlemleri Göster</value>
@@ -1095,7 +1095,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Hakkında</value>
   </data>
   <data name="Main_TsExit" xml:space="preserve">
-    <value>HASS.Agent&apos;tan çıkın</value>
+    <value>HASS.Agent'tan çıkın</value>
   </data>
   <data name="Main_BtnHide" xml:space="preserve">
     <value>&amp;Saklamak</value>
@@ -1134,10 +1134,10 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Hızlı İşlemler:</value>
   </data>
   <data name="Main_LblHomeAssistantApi" xml:space="preserve">
-    <value>Ev Asistanı API&apos;sı:</value>
+    <value>Ev Asistanı API'sı:</value>
   </data>
   <data name="Main_LblNotificationApi" xml:space="preserve">
-    <value>bildirim API&apos;si:</value>
+    <value>bildirim API'si:</value>
   </data>
   <data name="Onboarding_BtnNext" xml:space="preserve">
     <value>&amp;Sonraki</value>
@@ -1170,19 +1170,24 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>HASS.Agent Güncellemesi</value>
   </data>
   <data name="CommandsManager_CustomCommandDescription" xml:space="preserve">
-    <value>Özel bir komut yürütün. Bu komutlar özel yükseltme olmadan çalışır. Yükseltilmiş olarak çalıştırmak için bir Zamanlanmış Görev oluşturun ve görevinizi yürütmek için komut olarak &apos;schtasks /Run /TN &quot;TaskName&quot;&apos;i kullanın. Veya daha sıkı yürütme için &apos;düşük bütünlük olarak çalıştır&apos;ı etkinleştirin.</value>
+    <value>Özel bir komut yürütün. Bu komutlar özel yükseltme olmadan çalışır. Yükseltilmiş olarak çalıştırmak için bir Zamanlanmış Görev oluşturun ve görevinizi yürütmek için komut olarak 'schtasks /Run /TN "TaskName"'i kullanın. Veya daha sıkı yürütme için 'düşük bütünlük olarak çalıştır'ı etkinleştirin.</value>
   </data>
   <data name="CommandsManager_CustomExecutorCommandDescription" xml:space="preserve">
-    <value>Komutu, yapılandırılmış özel yürütücü aracılığıyla yürütür (Yapılandırma -&gt; Dış Araçlar&apos;da). Komutunuz &apos;olduğu gibi&apos; bir argüman olarak sağlanır, bu nedenle gerekirse kendi alıntılarınızı vb. sağlamanız gerekir.</value>
+    <value>Komutu, yapılandırılmış özel yürütücü aracılığıyla yürütür (Yapılandırma -&gt; Dış Araçlar'da). Komutunuz 'olduğu gibi' bir argüman olarak sağlanır, bu nedenle gerekirse kendi alıntılarınızı vb. sağlamanız gerekir.</value>
   </data>
   <data name="CommandsManager_HibernateCommandDescription" xml:space="preserve">
     <value>Makineyi hazırda bekletme moduna geçirir.</value>
   </data>
   <data name="CommandsManager_KeyCommandDescription" xml:space="preserve">
-    <value>Tek bir tuşa basmayı simüle eder. &apos;Anahtar kodu&apos; metin kutusuna tıklayın ve simüle edilmesini istediğiniz tuşa basın. İlgili anahtar kodu sizin için girilecektir. CTRL gibi daha fazla tuşa ve/veya değiştiriciye ihtiyacınız varsa, MultipleKeys komutunu kullanın.</value>
+    <value>Tek bir tuşa basmayı simüle eder.
+
+'Keycode' metin kutusuna tıklayın ve simüle edilmesini istediğiniz tuşa basın. İlgili anahtar kodu sizin için girilecektir.
+TAB tuşu için lütfen LCTRL+TAB kullanın.
+
+Daha fazla tuşa ve/veya CTRL gibi değiştiricilere ihtiyacınız varsa, MultipleKeys komutunu kullanın.</value>
   </data>
   <data name="CommandsManager_LaunchUrlCommandDescription" xml:space="preserve">
-    <value>Varsayılan tarayıcınızda varsayılan olarak sağlanan URL&apos;yi başlatır. &apos;Gizli&apos; kullanmak için Yapılandırma -&gt; Harici Araçlar&apos;da belirli bir tarayıcı sağlayın. Yalnızca belirli bir URL&apos;ye sahip bir pencere istiyorsanız (tam bir tarayıcı değil), bir &apos;WebView&apos; komutu kullanın.</value>
+    <value>Varsayılan tarayıcınızda varsayılan olarak sağlanan URL'yi başlatır. 'Gizli' kullanmak için Yapılandırma -&gt; Harici Araçlar'da belirli bir tarayıcı sağlayın. Yalnızca belirli bir URL'ye sahip bir pencere istiyorsanız (tam bir tarayıcı değil), bir 'WebView' komutu kullanın.</value>
   </data>
   <data name="CommandsManager_LockCommandDescription" xml:space="preserve">
     <value>Geçerli oturumu kilitler.</value>
@@ -1191,40 +1196,40 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Geçerli oturumun oturumunu kapatır.</value>
   </data>
   <data name="CommandsManager_MediaMuteCommandDescription" xml:space="preserve">
-    <value>&apos;Sessiz&apos; tuşunu simüle eder.</value>
+    <value>'Sessiz' tuşunu simüle eder.</value>
   </data>
   <data name="CommandsManager_MediaNextCommandDescription" xml:space="preserve">
-    <value>&apos;Sonraki Medya&apos; tuşunu simüle eder.</value>
+    <value>'Sonraki Medya' tuşunu simüle eder.</value>
   </data>
   <data name="CommandsManager_MediaPlayPauseCommandDescription" xml:space="preserve">
-    <value>&apos;Medya Duraklat/Oynat&apos; tuşunu simüle eder.</value>
+    <value>'Medya Duraklat/Oynat' tuşunu simüle eder.</value>
   </data>
   <data name="CommandsManager_MediaPreviousCommandDescription" xml:space="preserve">
-    <value>&apos;Önceki Medya&apos; tuşunu simüle eder.</value>
+    <value>'Önceki Medya' tuşunu simüle eder.</value>
   </data>
   <data name="CommandsManager_MediaVolumeDownCommandDescription" xml:space="preserve">
-    <value>&apos;Sesi Kısma&apos; tuşunu simüle eder.</value>
+    <value>'Sesi Kısma' tuşunu simüle eder.</value>
   </data>
   <data name="CommandsManager_MediaVolumeUpCommandDescription" xml:space="preserve">
-    <value>&apos;Sesi Aç&apos; tuşunu simüle eder.</value>
+    <value>'Sesi Aç' tuşunu simüle eder.</value>
   </data>
   <data name="CommandsManager_MultipleKeysCommandDescription" xml:space="preserve">
-    <value>Birden fazla tuşa basmayı simüle eder. Her tuşun arasına [ ] koymanız gerekir, aksi takdirde HASS.Agent onları ayırt edemez. Diyelim ki X TAB Y SHIFT-Z&apos;ye basmak istiyorsunuz, bu [X] [{TAB}] [Y] [+Z] olur. Kullanabileceğiniz birkaç numara vardır: - Bir parantezin basılmasını istiyorsanız, ondan kaçının, bu nedenle [ [\[] ve ] [\]] olur - Özel tuşlar { } arasında gidip gelir, örneğin {TAB} veya {UP} - SHIFT, CTRL için ^ ve ALT için % eklemek için bir tuşun önüne + koyun. Yani +C, SHIFT-C&apos;dir. Veya +(CD), SHIFT-C ve SHIFT-D&apos;dir, +CD ise SHIFT-C ve D&apos;dir - Birden fazla basış için {z 15} kullanın, bu, Z&apos;ye 15 kez basılacağı anlamına gelir. Daha fazla bilgi: https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys</value>
+    <value>Birden fazla tuşa basmayı simüle eder. Her tuşun arasına [ ] koymanız gerekir, aksi takdirde HASS.Agent onları ayırt edemez. Diyelim ki X TAB Y SHIFT-Z'ye basmak istiyorsunuz, bu [X] [{TAB}] [Y] [+Z] olur. Kullanabileceğiniz birkaç numara vardır: - Bir parantezin basılmasını istiyorsanız, ondan kaçının, bu nedenle [ [\[] ve ] [\]] olur - Özel tuşlar { } arasında gidip gelir, örneğin {TAB} veya {UP} - SHIFT, CTRL için ^ ve ALT için % eklemek için bir tuşun önüne + koyun. Yani +C, SHIFT-C'dir. Veya +(CD), SHIFT-C ve SHIFT-D'dir, +CD ise SHIFT-C ve D'dir - Birden fazla basış için {z 15} kullanın, bu, Z'ye 15 kez basılacağı anlamına gelir. Daha fazla bilgi: https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.sendkeys</value>
   </data>
   <data name="CommandsManager_PowershellCommandDescription" xml:space="preserve">
     <value>Bir Powershell komutu veya betiği yürütün. Bir komut dosyasının (*.ps1) konumunu veya tek satırlı bir komutu sağlayabilirsiniz. Bu, özel yükseklik olmadan çalışacaktır.</value>
   </data>
   <data name="CommandsManager_PublishAllSensorsCommandDescription" xml:space="preserve">
-    <value>Tüm sensör kontrollerini sıfırlar, tüm sensörleri değerlerini işlemeye ve göndermeye zorlar. Örneğin, bir HA yeniden başlatma sonrasında HASS.Agent&apos;ı tüm sensörlerinizi güncellemeye zorlamak istiyorsanız kullanışlıdır.</value>
+    <value>Tüm sensör kontrollerini sıfırlar, tüm sensörleri değerlerini işlemeye ve göndermeye zorlar. Örneğin, bir HA yeniden başlatma sonrasında HASS.Agent'ı tüm sensörlerinizi güncellemeye zorlamak istiyorsanız kullanışlıdır.</value>
   </data>
   <data name="CommandsManager_RestartCommandDescription" xml:space="preserve">
-    <value>Bir dakika sonra makineyi yeniden başlatır. İpucu: Yanlışlıkla mı tetiklendi? Kapatmayı iptal etmek için &apos;shutdown /a&apos; komutunu çalıştırın.</value>
+    <value>Bir dakika sonra makineyi yeniden başlatır. İpucu: Yanlışlıkla mı tetiklendi? Kapatmayı iptal etmek için 'shutdown /a' komutunu çalıştırın.</value>
   </data>
   <data name="CommandsManager_ShutdownCommandDescription" xml:space="preserve">
-    <value>Bir dakika sonra makineyi kapatır. İpucu: Yanlışlıkla mı tetiklendi? Kapatmayı iptal etmek için &apos;shutdown /a&apos; komutunu çalıştırın.</value>
+    <value>Bir dakika sonra makineyi kapatır. İpucu: Yanlışlıkla mı tetiklendi? Kapatmayı iptal etmek için 'shutdown /a' komutunu çalıştırın.</value>
   </data>
   <data name="CommandsManager_SleepCommandDescription" xml:space="preserve">
-    <value>Makineyi uyku moduna geçirir. Not: Windows&apos;taki bir sınırlama nedeniyle, bu yalnızca hazırda bekletme modu devre dışı bırakıldığında çalışır, aksi takdirde yalnızca hazırda bekletme moduna geçer. Bunu atlatmak için NirCmd (http://www.nirsoft.net/utils/nircmd.html) gibi bir şey kullanabilirsiniz.</value>
+    <value>Makineyi uyku moduna geçirir. Not: Windows'taki bir sınırlama nedeniyle, bu yalnızca hazırda bekletme modu devre dışı bırakıldığında çalışır, aksi takdirde yalnızca hazırda bekletme moduna geçer. Bunu atlatmak için NirCmd (http://www.nirsoft.net/utils/nircmd.html) gibi bir şey kullanabilirsiniz.</value>
   </data>
   <data name="ConfigExternalTools_BtnExternalBrowserIncognitoTest_MessageBox1" xml:space="preserve">
     <value>Lütfen tarayıcınızın ikili dosyasının konumunu girin! (.exe dosyası)</value>
@@ -1242,7 +1247,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Lütfen geçerli bir API anahtarı girin!</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox2" xml:space="preserve">
-    <value>Lütfen Ev Asistanınızın URI&apos;si için bir değer girin.</value>
+    <value>Lütfen Ev Asistanınızın URI'si için bir değer girin.</value>
   </data>
   <data name="ConfigHomeAssistantApi_BtnTestApi_MessageBox3" xml:space="preserve">
     <value>Bağlanılamadı, aşağıdaki hata döndürüldü: {0}</value>
@@ -1257,7 +1262,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Temizlik..</value>
   </data>
   <data name="ConfigNotifications_BtnSendTestNotification_MessageBox1" xml:space="preserve">
-    <value>Bildirimler şu anda devre dışı, lütfen bunları etkinleştirin ve HASS.Agent&apos;ı yeniden başlatın, ardından tekrar deneyin.</value>
+    <value>Bildirimler şu anda devre dışı, lütfen bunları etkinleştirin ve HASS.Agent'ı yeniden başlatın, ardından tekrar deneyin.</value>
   </data>
   <data name="ConfigNotifications_BtnSendTestNotification_MessageBox2" xml:space="preserve">
     <value>Test bildiriminin görünmesi gerekirdi, almadıysanız lütfen günlükleri kontrol edin veya sorun giderme ipuçları için belgelere bakın. Not: Bu, yalnızca yerel olarak bildirimlerin gösterilip gösterilmeyeceğini test eder!</value>
@@ -1290,7 +1295,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Hizmeti durdururken bir şeyler ters gitti, UAC istemine izin verdiniz mi? Daha fazla bilgi için HASS.Agent (hizmet değil) günlüklerini kontrol edin.</value>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox1" xml:space="preserve">
-    <value>Hizmet &apos;devre dışı&apos; olarak ayarlanmıştır, bu nedenle başlatılamaz. Lütfen önce hizmeti etkinleştirin ve tekrar deneyin.</value>
+    <value>Hizmet 'devre dışı' olarak ayarlanmıştır, bu nedenle başlatılamaz. Lütfen önce hizmeti etkinleştirin ve tekrar deneyin.</value>
   </data>
   <data name="ConfigService_BtnStartService_MessageBox2" xml:space="preserve">
     <value>Hizmeti başlatırken bir şeyler ters gitti, UAC istemine izin verdiniz mi? Daha fazla bilgi için HASS.Agent (hizmet değil) günlüklerini kontrol edin.</value>
@@ -1326,7 +1331,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Girişte Başlat etkinleştirildi!</value>
   </data>
   <data name="OnboardingStartup_EnableNow" xml:space="preserve">
-    <value>Girişte Başlat&apos;ı şimdi etkinleştirmek istiyor musunuz?</value>
+    <value>Girişte Başlat'ı şimdi etkinleştirmek istiyor musunuz?</value>
   </data>
   <data name="OnboardingStartup_AlreadyActivated" xml:space="preserve">
     <value>Girişte Başlat zaten etkinleştirildi, her şey hazır!</value>
@@ -1335,7 +1340,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Oturum Açılırken Başlat etkinleştiriliyor..</value>
   </data>
   <data name="OnboardingStartup_Failed" xml:space="preserve">
-    <value>Bir şeyler yanlış gitti. Tekrar deneyebilir veya sonraki sayfaya atlayıp HASS.Agent&apos;ın yeniden başlatılmasından sonra yeniden deneyebilirsiniz.</value>
+    <value>Bir şeyler yanlış gitti. Tekrar deneyebilir veya sonraki sayfaya atlayıp HASS.Agent'ın yeniden başlatılmasından sonra yeniden deneyebilirsiniz.</value>
   </data>
   <data name="OnboardingStartup_BtnSetLaunchOnLogin_2" xml:space="preserve">
     <value>Oturum Açıldığında Başlatmayı Etkinleştir</value>
@@ -1344,7 +1349,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Lütfen geçerli bir API anahtarı sağlayın.</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox2" xml:space="preserve">
-    <value>Lütfen Ev Asistanınızın URI&apos;sini girin.</value>
+    <value>Lütfen Ev Asistanınızın URI'sini girin.</value>
   </data>
   <data name="OnboardingApi_BtnTest_MessageBox3" xml:space="preserve">
     <value>Bağlanılamadı, aşağıdaki hata döndürüldü: {0}</value>
@@ -1380,7 +1385,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Yetkisiz</value>
   </data>
   <data name="ServiceConnect_UnauthorizedMessage" xml:space="preserve">
-    <value>Servisle iletişime geçme yetkiniz yok. Doğru auth ID&apos;niz varsa, şimdi ayarlayabilir ve tekrar deneyebilirsiniz.</value>
+    <value>Servisle iletişime geçme yetkiniz yok. Doğru auth ID'niz varsa, şimdi ayarlayabilir ve tekrar deneyebilirsiniz.</value>
   </data>
   <data name="ServiceConnect_SettingsFailed" xml:space="preserve">
     <value>Ayarlar getirilemedi!</value>
@@ -1407,7 +1412,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Hizmet, yapılandırılmış sensörlerini isterken bir hata döndürdü. Daha fazla bilgi için günlükleri kontrol edin. Yapılandırma panelinden günlükleri açabilir ve hizmeti yönetebilirsiniz.</value>
   </data>
   <data name="ServiceGeneral_TbAuthId_MessageBox1" xml:space="preserve">
-    <value>Boş bir kimlik doğrulama kimliğinin saklanması, tüm HASS.Agent&apos;ların hizmete erişmesine izin verecektir. Bunu istediğinden emin misin?</value>
+    <value>Boş bir kimlik doğrulama kimliğinin saklanması, tüm HASS.Agent'ların hizmete erişmesine izin verecektir. Bunu istediğinden emin misin?</value>
   </data>
   <data name="ServiceGeneral_SavingFailedMessageBox" xml:space="preserve">
     <value>Kaydederken bir hata oluştu, daha fazla bilgi için günlükleri kontrol edin.</value>
@@ -1425,7 +1430,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Bu bilgisayardaki her HASS.Agent örneğinin uydu hizmetine bağlanmasını istemiyorsanız bir kimlik doğrulama kimliği ayarlayın. Yalnızca doğru kimliğe sahip örnekler bağlanabilir. Herkesin bağlanmasına izin vermek için boş bırakın.</value>
   </data>
   <data name="ServiceGeneral_LblDeviceNameInfo_MessageBox1" xml:space="preserve">
-    <value>Bu, uydu hizmetinin kendisini Home Assistant&apos;a kaydettiği addır. Varsayılan olarak, bilgisayarınızın adı artı &apos;-uydu&apos;dur.</value>
+    <value>Bu, uydu hizmetinin kendisini Home Assistant'a kaydettiği addır. Varsayılan olarak, bilgisayarınızın adı artı '-uydu'dur.</value>
   </data>
   <data name="ServiceGeneral_LblDisconGraceInfo_MessageBox1" xml:space="preserve">
     <value>Uydu hizmetinin, MQTT aracısına bağlantının koptuğunu bildirmeden önce bekleyeceği süre.</value>
@@ -1503,10 +1508,10 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Bu ada sahip bir komut zaten var, devam etmek istediğinizden emin misiniz?</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox4" xml:space="preserve">
-    <value>Bir komut sağlanmazsa, bu varlığı Home Assistant aracılığıyla yalnızca bir &apos;eylem&apos; değeriyle kullanabilirsiniz, olduğu gibi çalıştırdığınızda herhangi bir işlem yapılmaz. Devam etmek istediğinizden emin misiniz?</value>
+    <value>Bir komut sağlanmazsa, bu varlığı Home Assistant aracılığıyla yalnızca bir 'eylem' değeriyle kullanabilirsiniz, olduğu gibi çalıştırdığınızda herhangi bir işlem yapılmaz. Devam etmek istediğinizden emin misiniz?</value>
   </data>
   <data name="CommandsMod_MessageBox_Action" xml:space="preserve">
-    <value>Bir komut veya komut dosyası girmezseniz, bu varlığı yalnızca Home Assistant aracılığıyla bir &apos;eylem&apos; değeriyle kullanabilirsiniz. Olduğu gibi çalıştırmak hiçbir şey yapmaz. Bunu istediğinden emin misin?</value>
+    <value>Bir komut veya komut dosyası girmezseniz, bu varlığı yalnızca Home Assistant aracılığıyla bir 'eylem' değeriyle kullanabilirsiniz. Olduğu gibi çalıştırmak hiçbir şey yapmaz. Bunu istediğinden emin misin?</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox5" xml:space="preserve">
     <value>Lütfen bir anahtar kodu girin!</value>
@@ -1515,7 +1520,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Anahtarlar kontrol edilemedi: {0}</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox7" xml:space="preserve">
-    <value>Bir URL sağlanmazsa, bu varlığı Home Assistant aracılığıyla yalnızca bir &apos;eylem&apos; değeriyle kullanabilirsiniz, olduğu gibi çalıştırdığınızda herhangi bir işlem yapılmaz. Devam etmek istediğinizden emin misiniz?</value>
+    <value>Bir URL sağlanmazsa, bu varlığı Home Assistant aracılığıyla yalnızca bir 'eylem' değeriyle kullanabilirsiniz, olduğu gibi çalıştırdığınızda herhangi bir işlem yapılmaz. Devam etmek istediğinizden emin misiniz?</value>
   </data>
   <data name="CommandsMod_LblSetting_Command" xml:space="preserve">
     <value>Emretmek</value>
@@ -1554,10 +1559,10 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Bu, yalnızca belirli konumlardaki dosyaları kaydedip değiştirebileceği anlamına gelir,</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg3" xml:space="preserve">
-    <value>&apos;%USERPROFILE%\AppData\LocalLow&apos; klasörü gibi veya</value>
+    <value>'%USERPROFILE%\AppData\LocalLow' klasörü gibi veya</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg4" xml:space="preserve">
-    <value>&apos;HKEY_CURRENT_USER\Software\AppDataLow&apos; kayıt defteri anahtarı.</value>
+    <value>'HKEY_CURRENT_USER\Software\AppDataLow' kayıt defteri anahtarı.</value>
   </data>
   <data name="CommandsMod_LblIntegrityInfo_InfoMsg5" xml:space="preserve">
     <value>Bundan etkilenmediğinden emin olmak için komutunuzu test etmelisiniz!</value>
@@ -1668,10 +1673,10 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>yalnızca {0}!</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox1" xml:space="preserve">
-    <value>Cihazınızın adını değiştirdiniz. Tüm sensörleriniz ve komutlarınız artık yayından kaldırılacak ve HASS.Agent daha sonra bunları yeniden yayınlamak için yeniden başlatılacaktır. Endişelenmeyin, mevcut adlarını koruyacaklar, böylece otomasyonlarınız veya komut dosyalarınız çalışmaya devam edecek. Not: ad &apos;temizlenecek&apos;, bu da harfler, rakamlar ve boşluklar dışındaki her şeyin bir alt çizgi ile değiştirileceği anlamına gelir. Bu, HA tarafından gereklidir.</value>
+    <value>Cihazınızın adını değiştirdiniz. Tüm sensörleriniz ve komutlarınız artık yayından kaldırılacak ve HASS.Agent daha sonra bunları yeniden yayınlamak için yeniden başlatılacaktır. Endişelenmeyin, mevcut adlarını koruyacaklar, böylece otomasyonlarınız veya komut dosyalarınız çalışmaya devam edecek. Not: ad 'temizlenecek', bu da harfler, rakamlar ve boşluklar dışındaki her şeyin bir alt çizgi ile değiştirileceği anlamına gelir. Bu, HA tarafından gereklidir.</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox2" xml:space="preserve">
-    <value>Yerel API&apos;nin bağlantı noktasını değiştirdiniz. Bu yeni limanın rezerve edilmesi gerekiyor. Bunu yapmak için bir UAC isteği alacaksınız, lütfen onaylayın.</value>
+    <value>Yerel API'nin bağlantı noktasını değiştirdiniz. Bu yeni limanın rezerve edilmesi gerekiyor. Bunu yapmak için bir UAC isteği alacaksınız, lütfen onaylayın.</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox3" xml:space="preserve">
     <value>Bir şeyler yanlış gitti! Lütfen gerekli komutu manuel olarak yürütün. Panonuza kopyalandı, sadece yükseltilmiş bir komut istemine yapıştırmanız gerekiyor. Güvenlik duvarı kuralınızın bağlantı noktasını da değiştirmeyi unutmayın.</value>
@@ -1683,13 +1688,13 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Yeniden başlatmaya hazırlanırken bir şeyler ters gitti. Lütfen manuel olarak yeniden başlatın.</value>
   </data>
   <data name="Configuration_ProcessChanges_MessageBox5" xml:space="preserve">
-    <value>Yapılandırmanız kaydedildi. Çoğu değişiklik, HASS.Agent&apos;ın yürürlüğe girmeden önce yeniden başlatılmasını gerektirir. Şimdi yeniden başlatmak istiyor musunuz?</value>
+    <value>Yapılandırmanız kaydedildi. Çoğu değişiklik, HASS.Agent'ın yürürlüğe girmeden önce yeniden başlatılmasını gerektirir. Şimdi yeniden başlatmak istiyor musunuz?</value>
   </data>
   <data name="Main_Load_MessageBox1" xml:space="preserve">
-    <value>Ayarlarınız yüklenirken bir şeyler ters gitti. &apos;config&apos; alt klasöründeki appsettings.json dosyasını kontrol edin veya yeni bir başlangıç yapmak için silin.</value>
+    <value>Ayarlarınız yüklenirken bir şeyler ters gitti. 'config' alt klasöründeki appsettings.json dosyasını kontrol edin veya yeni bir başlangıç yapmak için silin.</value>
   </data>
   <data name="Main_Load_MessageBox2" xml:space="preserve">
-    <value>HASS.Agent başlatılırken bir hata oluştu. Lütfen günlükleri kontrol edin ve GitHub&apos;da bir hata raporu oluşturun.</value>
+    <value>HASS.Agent başlatılırken bir hata oluştu. Lütfen günlükleri kontrol edin ve GitHub'da bir hata raporu oluşturun.</value>
   </data>
   <data name="Main_BtnSensorsManage_Ready" xml:space="preserve">
     <value>Yerel ve Sensörler</value>
@@ -1792,13 +1797,13 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>İstemci sertifika dosyası bulunamadı.</value>
   </data>
   <data name="HassApiManager_CheckHassConfig_UnableToConnect" xml:space="preserve">
-    <value>Bağlanamıyor, URI&apos;yi kontrol edin.</value>
+    <value>Bağlanamıyor, URI'yi kontrol edin.</value>
   </data>
   <data name="HassApiManager_CheckHassConfig_ConfigFailed" xml:space="preserve">
     <value>Yapılandırma getirilemiyor, lütfen API anahtarını kontrol edin.</value>
   </data>
   <data name="HassApiManager_ConnectionFailed" xml:space="preserve">
-    <value>Bağlanamıyor, lütfen URI&apos;yi ve yapılandırmayı kontrol edin.</value>
+    <value>Bağlanamıyor, lütfen URI'yi ve yapılandırmayı kontrol edin.</value>
   </data>
   <data name="HassApiManager_ToolTip_QuickActionFailed" xml:space="preserve">
     <value>hızlı eylem: eylem başarısız oldu, bilgi için günlükleri kontrol edin</value>
@@ -1816,22 +1821,22 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>MQTT: Bağlantı kesildi</value>
   </data>
   <data name="NotifierManager_Initialize_MessageBox1" xml:space="preserve">
-    <value>API&apos;yi {0} bağlantı noktasına bağlamaya çalışırken hata oluştu. HASS.Agent&apos;ın başka hiçbir örneğinin çalışmadığından ve bağlantı noktasının kullanılabilir ve kayıtlı olduğundan emin olun.</value>
+    <value>API'yi {0} bağlantı noktasına bağlamaya çalışırken hata oluştu. HASS.Agent'ın başka hiçbir örneğinin çalışmadığından ve bağlantı noktasının kullanılabilir ve kayıtlı olduğundan emin olun.</value>
   </data>
   <data name="SensorsManager_ActiveWindowSensorDescription" xml:space="preserve">
     <value>Geçerli etkin pencerenin başlığını sağlar.</value>
   </data>
   <data name="SensorsManager_AudioSensorsDescription" xml:space="preserve">
-    <value>Cihazınızın sesinin çeşitli yönleri hakkında bilgi sağlar: Mevcut en yüksek ses seviyesi (basit bir &apos;bir şey çalıyor&apos; değeri olarak kullanılabilir). Varsayılan ses aygıtı: ad, durum ve ses düzeyi. Sesli oturumlarınızın özeti: uygulama adı, sessiz durumu, ses düzeyi ve mevcut en yüksek ses düzeyi.</value>
+    <value>Cihazınızın sesinin çeşitli yönleri hakkında bilgi sağlar: Mevcut en yüksek ses seviyesi (basit bir 'bir şey çalıyor' değeri olarak kullanılabilir). Varsayılan ses aygıtı: ad, durum ve ses düzeyi. Sesli oturumlarınızın özeti: uygulama adı, sessiz durumu, ses düzeyi ve mevcut en yüksek ses düzeyi.</value>
   </data>
   <data name="SensorsManager_BatterySensorsDescription" xml:space="preserve">
     <value>Mevcut şarj durumunu, tam şarjda tahmini dakika miktarını, yüzde olarak kalan şarjı, dakika cinsinden kalan şarjı ve elektrik hattı durumunu gösteren bir sensör sağlar.</value>
   </data>
   <data name="SensorsManager_CpuLoadSensorDescription" xml:space="preserve">
-    <value>İlk CPU&apos;nun mevcut yükünü yüzde olarak sağlar.</value>
+    <value>İlk CPU'nun mevcut yükünü yüzde olarak sağlar.</value>
   </data>
   <data name="SensorsManager_CurrentClockSpeedSensorDescription" xml:space="preserve">
-    <value>İlk CPU&apos;nun mevcut saat hızını sağlar.</value>
+    <value>İlk CPU'nun mevcut saat hızını sağlar.</value>
   </data>
   <data name="SensorsManager_CurrentVolumeSensorDescription" xml:space="preserve">
     <value>Geçerli ses seviyesini yüzde olarak sağlar. Şu anda varsayılan cihazınızın hacmini alıyor.</value>
@@ -1843,16 +1848,16 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Test amaçlı kukla sensör, 0 ile 100 arasında rastgele bir tamsayı değeri gönderir.</value>
   </data>
   <data name="SensorsManager_GpuLoadSensorDescription" xml:space="preserve">
-    <value>Yüzde olarak ilk GPU&apos;nun mevcut yükünü sağlar.</value>
+    <value>Yüzde olarak ilk GPU'nun mevcut yükünü sağlar.</value>
   </data>
   <data name="SensorsManager_GpuTemperatureSensorDescription" xml:space="preserve">
-    <value>İlk GPU&apos;nun mevcut sıcaklığını sağlar.</value>
+    <value>İlk GPU'nun mevcut sıcaklığını sağlar.</value>
   </data>
   <data name="SensorsManager_LastActiveSensorDescription" xml:space="preserve">
     <value>Kullanıcının herhangi bir girdi sağladığı son anı içeren bir tarih saat değeri sağlar.</value>
   </data>
   <data name="SensorsManager_LastBootSensorDescription" xml:space="preserve">
-    <value>Sistemin (yeniden) başlatıldığı son anı içeren bir tarih saat değeri sağlar. Önemli: Windows&apos;un FastBoot seçeneği bu değeri atabilir, çünkü bu bir hazırda bekletme modudur. Güç Seçenekleri -&gt; &apos;Güç düğmelerinin ne yapacağını seçin&apos; -&gt; &apos;Hızlı başlatmayı aç&apos; seçeneğinin işaretini kaldırarak devre dışı bırakabilirsiniz. SSD&apos;li modern makineler için pek bir fark yaratmaz, ancak devre dışı bırakmak, yeniden başlattıktan sonra temiz bir durum almanızı sağlar.</value>
+    <value>Sistemin (yeniden) başlatıldığı son anı içeren bir tarih saat değeri sağlar. Önemli: Windows'un FastBoot seçeneği bu değeri atabilir, çünkü bu bir hazırda bekletme modudur. Güç Seçenekleri -&gt; 'Güç düğmelerinin ne yapacağını seçin' -&gt; 'Hızlı başlatmayı aç' seçeneğinin işaretini kaldırarak devre dışı bırakabilirsiniz. SSD'li modern makineler için pek bir fark yaratmaz, ancak devre dışı bırakmak, yeniden başlattıktan sonra temiz bir durum almanızı sağlar.</value>
   </data>
   <data name="SensorsManager_LastSystemStateChangeSensorDescription" xml:space="preserve">
     <value>Son sistem durumu değişikliğini sağlar: ApplicationStarted, Logoff, SystemShutdown, Resume, Suspend, ConsoleConnect, ConsoleDisconnect, RemoteConnect, RemoteDisconnect, SessionLock, SessionLogoff, SessionLogon, SessionRemoteControl ve SessionUnlock.</value>
@@ -1878,14 +1883,14 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Seçilen ağ kartının/kartlarının kart bilgilerini, yapılandırmasını, aktarım ve paket istatistiklerini ve adreslerini (ip, mac, dhcp, dns) sağlar. Bu çok değerli bir sensördür.</value>
   </data>
   <data name="SensorsManager_PerformanceCounterSensorDescription" xml:space="preserve">
-    <value>Bir performans sayacının değerlerini sağlar. Örneğin, yerleşik CPU yük sensörü şu değerleri kullanır: Kategori: İşlemci Sayacı: % İşlemci Zaman Örneği: _Toplam Sayaçları Windows&apos; &apos;perfmon.exe&apos; aracıyla keşfedebilirsiniz.</value>
+    <value>Bir performans sayacının değerlerini sağlar. Örneğin, yerleşik CPU yük sensörü şu değerleri kullanır: Kategori: İşlemci Sayacı: % İşlemci Zaman Örneği: _Toplam Sayaçları Windows' 'perfmon.exe' aracıyla keşfedebilirsiniz.</value>
   </data>
   <data name="SensorsManager_ProcessActiveSensorDescription" xml:space="preserve">
     <value>İşlemin etkin örneklerinin sayısını sağlar.</value>
     <comment>Fuzzy</comment>
   </data>
   <data name="SensorsManager_ServiceStateSensorDescription" xml:space="preserve">
-    <value>Sağlanan hizmetin durumunu döndürür: Bulunamadı, Durduruldu, StartPending, StopPending, Running, ContinuePending, PausePending veya Paused. &apos;Görünen ad&apos; değil, &apos;Hizmet adı&apos; sağladığınızdan emin olun.</value>
+    <value>Sağlanan hizmetin durumunu döndürür: Bulunamadı, Durduruldu, StartPending, StopPending, Running, ContinuePending, PausePending veya Paused. 'Görünen ad' değil, 'Hizmet adı' sağladığınızdan emin olun.</value>
   </data>
   <data name="SensorsManager_SessionStateSensorDescription" xml:space="preserve">
     <value>Geçerli oturum durumunu sağlar: Kilitli, Kilitli Değil veya Bilinmiyor. Oturum durumu değişikliklerini izlemek için bir LastSystemStateChangeSensor kullanın.</value>
@@ -2311,13 +2316,13 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Uygulama Başladı</value>
   </data>
   <data name="ServiceGeneral_LblInfo2" xml:space="preserve">
-    <value>Uydu hizmetini, oturum açmak zorunda kalmadan sensörleri ve komutları çalıştırmak için kullanabilirsiniz. Tüm türler mevcut değildir, örneğin &apos;LaunchUrl&apos; komutu yalnızca normal bir komut olarak eklenebilir.</value>
+    <value>Uydu hizmetini, oturum açmak zorunda kalmadan sensörleri ve komutları çalıştırmak için kullanabilirsiniz. Tüm türler mevcut değildir, örneğin 'LaunchUrl' komutu yalnızca normal bir komut olarak eklenebilir.</value>
   </data>
   <data name="SensorsConfig_ClmValue" xml:space="preserve">
     <value>Bilinen Son Değer</value>
   </data>
   <data name="LocalApiManager_Initialize_MessageBox1" xml:space="preserve">
-    <value>API&apos;yi {0} bağlantı noktasına bağlamaya çalışırken hata oluştu. HASS.Agent&apos;ın başka hiçbir örneğinin çalışmadığından ve bağlantı noktasının kullanılabilir ve kayıtlı olduğundan emin olun.</value>
+    <value>API'yi {0} bağlantı noktasına bağlamaya çalışırken hata oluştu. HASS.Agent'ın başka hiçbir örneğinin çalışmadığından ve bağlantı noktasının kullanılabilir ve kayıtlı olduğundan emin olun.</value>
   </data>
   <data name="CommandType_SendWindowToFrontCommand" xml:space="preserve">
     <value>SendWindowToFront</value>
@@ -2326,16 +2331,16 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Web Görünümü</value>
   </data>
   <data name="CommandsManager_WebViewCommandDescription" xml:space="preserve">
-    <value>Sağlanan URL ile bir pencere gösterir. Bu, &apos;LaunchUrl&apos; komutundan farklıdır, çünkü tam teşekküllü bir tarayıcı yüklemez, yalnızca kendi penceresinde sağlanan URL&apos;yi yükler. Bunu, örneğin Home Assistant&apos;ın kontrol panelini hızlı bir şekilde göstermek için kullanabilirsiniz. Varsayılan olarak, çerezleri süresiz olarak saklar, bu nedenle yalnızca bir kez oturum açmanız gerekir.</value>
+    <value>Sağlanan URL ile bir pencere gösterir. Bu, 'LaunchUrl' komutundan farklıdır, çünkü tam teşekküllü bir tarayıcı yüklemez, yalnızca kendi penceresinde sağlanan URL'yi yükler. Bunu, örneğin Home Assistant'ın kontrol panelini hızlı bir şekilde göstermek için kullanabilirsiniz. Varsayılan olarak, çerezleri süresiz olarak saklar, bu nedenle yalnızca bir kez oturum açmanız gerekir.</value>
   </data>
   <data name="HassDomain_HASSAgentCommands" xml:space="preserve">
     <value>HASS.Ajan Komutları</value>
   </data>
   <data name="CommandsManager_CommandsManager_SendWindowToFrontCommandDescription" xml:space="preserve">
-    <value>Belirtilen işlemi arar ve ana penceresini öne göndermeye çalışır. Uygulama simge durumuna küçültülürse geri yüklenir. Örnek: VLC&apos;yi ön plana göndermek istiyorsanız, &apos;vlc&apos; kullanın.</value>
+    <value>Belirtilen işlemi arar ve ana penceresini öne göndermeye çalışır. Uygulama simge durumuna küçültülürse geri yüklenir. Örnek: VLC'yi ön plana göndermek istiyorsanız, 'vlc' kullanın.</value>
   </data>
   <data name="CommandsMod_BtnStore_MessageBox8" xml:space="preserve">
-    <value>Komutu yapılandırmazsanız, bu varlığı yalnızca Home Assistant aracılığıyla bir &apos;eylem&apos; değeriyle kullanabilirsiniz ve varsayılan ayarlar kullanılarak görünür, olduğu gibi çalıştırıldığında herhangi bir işlem yapılmaz. Bunu yapmak istediğinden emin misin?</value>
+    <value>Komutu yapılandırmazsanız, bu varlığı yalnızca Home Assistant aracılığıyla bir 'eylem' değeriyle kullanabilirsiniz ve varsayılan ayarlar kullanılarak görünür, olduğu gibi çalıştırıldığında herhangi bir işlem yapılmaz. Bunu yapmak istediğinden emin misin?</value>
   </data>
   <data name="ConfigLocalStorage_BtnClearAudioCache" xml:space="preserve">
     <value>Ses Önbelleğini Temizle</value>
@@ -2356,7 +2361,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>WebView önbelleği temizlendi!</value>
   </data>
   <data name="Main_CheckDpiScalingFactor_MessageBox1" xml:space="preserve">
-    <value>Görünüşe göre alternatif bir ölçeklendirme kullanıyorsunuz. Bu, HASS.Agent&apos;ın bazı bölümlerinin amaçlandığı gibi görünmemesine neden olabilir. Lütfen kullanılamayan yönleri GitHub&apos;da bildirin. Teşekkürler! Not: Bu mesaj yalnızca bir kez gösterilir.</value>
+    <value>Görünüşe göre alternatif bir ölçeklendirme kullanıyorsunuz. Bu, HASS.Agent'ın bazı bölümlerinin amaçlandığı gibi görünmemesine neden olabilir. Lütfen kullanılamayan yönleri GitHub'da bildirin. Teşekkürler! Not: Bu mesaj yalnızca bir kez gösterilir.</value>
   </data>
   <data name="WebViewCommandConfig_SetStoredVariables_MessageBox1" xml:space="preserve">
     <value>Depolanan komut ayarları yüklenemiyor, varsayılana sıfırlanıyor.</value>
@@ -2368,13 +2373,13 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Bağlantı Noktası ve Rezervasyonu Yürüt</value>
   </data>
   <data name="ConfigLocalApi_CbLocalApiActive" xml:space="preserve">
-    <value>&amp;Yerel API&apos;yi Etkinleştir</value>
+    <value>&amp;Yerel API'yi Etkinleştir</value>
   </data>
   <data name="ConfigLocalApi_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent&apos;ın kendi yerel API&apos;si vardır, bu nedenle Home Assistant istek gönderebilir (örneğin bir bildirim göndermek için). Buradan global olarak yapılandırabilir ve daha sonra bağımlı bölümleri (şu anda bildirimler ve mediaplayer) yapılandırabilirsiniz. Not: Yeni entegrasyonun çalışması için bu gerekli değildir. Yalnızca MQTT kullanmıyorsanız etkinleştirin ve kullanın.</value>
+    <value>HASS.Agent'ın kendi yerel API'si vardır, bu nedenle Home Assistant istek gönderebilir (örneğin bir bildirim göndermek için). Buradan global olarak yapılandırabilir ve daha sonra bağımlı bölümleri (şu anda bildirimler ve mediaplayer) yapılandırabilirsiniz. Not: Yeni entegrasyonun çalışması için bu gerekli değildir. Yalnızca MQTT kullanmıyorsanız etkinleştirin ve kullanın.</value>
   </data>
   <data name="ConfigLocalApi_LblInfo2" xml:space="preserve">
-    <value>İstekleri dinleyebilmek için HASS.Agent&apos;ın portunun ayrılmış ve güvenlik duvarınızda açılmış olması gerekir. Bunu sizin için yaptırmak için bu düğmeyi kullanabilirsiniz.</value>
+    <value>İstekleri dinleyebilmek için HASS.Agent'ın portunun ayrılmış ve güvenlik duvarınızda açılmış olması gerekir. Bunu sizin için yaptırmak için bu düğmeyi kullanabilirsiniz.</value>
   </data>
   <data name="ConfigLocalApi_LblPort" xml:space="preserve">
     <value>&amp;Liman</value>
@@ -2407,10 +2412,10 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>&amp;Medya Oynatıcı İşlevselliğini Etkinleştir</value>
   </data>
   <data name="ConfigMediaPlayer_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent, Home Assistant için bir medya oynatıcı görevi görebilir, böylece çalmakta olan herhangi bir medyayı görebilir ve kontrol edebilir ve metinden konuşmaya gönderebilirsiniz. MQTT&apos;yi etkinleştirdiyseniz, cihazınız otomatik olarak eklenir. Aksi takdirde, yerel API&apos;yi kullanmak için entegrasyonu manuel olarak yapılandırın.</value>
+    <value>HASS.Agent, Home Assistant için bir medya oynatıcı görevi görebilir, böylece çalmakta olan herhangi bir medyayı görebilir ve kontrol edebilir ve metinden konuşmaya gönderebilirsiniz. MQTT'yi etkinleştirdiyseniz, cihazınız otomatik olarak eklenir. Aksi takdirde, yerel API'yi kullanmak için entegrasyonu manuel olarak yapılandırın.</value>
   </data>
   <data name="ConfigMediaPlayer_LblInfo2" xml:space="preserve">
-    <value>Bir şey çalışmıyorsa, aşağıdaki adımları denediğinizden emin olun: - HASS.Agent entegrasyonunu kurun - Home Assistant&apos;ı yeniden başlatın - MQTT etkinken HASS.Agent&apos;ın etkin olduğundan emin olun! - Cihazınız otomatik olarak bir varlık olarak algılanmalı ve eklenmelidir - İsteğe bağlı olarak: yerel API&apos;yi kullanarak manuel olarak ekleyin</value>
+    <value>Bir şey çalışmıyorsa, aşağıdaki adımları denediğinizden emin olun: - HASS.Agent entegrasyonunu kurun - Home Assistant'ı yeniden başlatın - MQTT etkinken HASS.Agent'ın etkin olduğundan emin olun! - Cihazınız otomatik olarak bir varlık olarak algılanmalı ve eklenmelidir - İsteğe bağlı olarak: yerel API'yi kullanarak manuel olarak ekleyin</value>
   </data>
   <data name="ConfigMediaPlayer_LblLocalApiDisabled" xml:space="preserve">
     <value>Yerel API devre dışıdır, ancak medya oynatıcının çalışması için buna ihtiyacı vardır.</value>
@@ -2443,7 +2448,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Boyut (px)</value>
   </data>
   <data name="ConfigTrayIcon_LblWebViewUrl" xml:space="preserve">
-    <value>&amp;WebView URL&apos;si (Örneğin, Home Assistant Dashboard URL&apos;niz)</value>
+    <value>&amp;WebView URL'si (Örneğin, Home Assistant Dashboard URL'niz)</value>
   </data>
   <data name="Configuration_TablLocalApi" xml:space="preserve">
     <value>Yerel API</value>
@@ -2455,10 +2460,10 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Tepsi ikonu</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg1" xml:space="preserve">
-    <value>Giriş dilinizin &apos;{0}&apos; varsayılan CTRL-ALT-Q kısayol tuşuyla çakıştığı biliniyor. Lütfen kendinizinkini ayarlayın.</value>
+    <value>Giriş dilinizin '{0}' varsayılan CTRL-ALT-Q kısayol tuşuyla çakıştığı biliniyor. Lütfen kendinizinkini ayarlayın.</value>
   </data>
   <data name="HelperFunctions_InputLanguageCheckDiffers_ErrorMsg2" xml:space="preserve">
-    <value>Giriş diliniz &apos;{0}&apos; bilinmiyor ve varsayılan CTRL-ALT-Q kısayol tuşuyla çakışabilir. Lütfen emin olmak için kontrol edin. Varsa, listeye eklenebilmesi için GitHub&apos;da bir bilet açmayı düşünün.</value>
+    <value>Giriş diliniz '{0}' bilinmiyor ve varsayılan CTRL-ALT-Q kısayol tuşuyla çakışabilir. Lütfen emin olmak için kontrol edin. Varsa, listeye eklenebilmesi için GitHub'da bir bilet açmayı düşünün.</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg1" xml:space="preserve">
     <value>Anahtar bulunamadı</value>
@@ -2470,7 +2475,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Anahtarlar ayrıştırılırken hata oluştu, daha fazla bilgi için lütfen günlükleri kontrol edin.</value>
   </data>
   <data name="HelperFunctions_ParseMultipleKeys_ErrorMsg4" xml:space="preserve">
-    <value>Açık parantezlerin sayısı (&apos;[&apos;), kapalı parantezlerin sayısına karşılık gelmez. (&apos;]&apos;)! ({0} - {1})</value>
+    <value>Açık parantezlerin sayısı ('['), kapalı parantezlerin sayısına karşılık gelmez. (']')! ({0} - {1})</value>
   </data>
   <data name="Help_LblDocumentation" xml:space="preserve">
     <value>belgeler</value>
@@ -2488,10 +2493,10 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Uydu Hizmetini Yönet</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo1" xml:space="preserve">
-    <value>Bildirimleri kullanmak için Home Assistant&apos;ta HASS.Agent-notifier entegrasyonunu kurmanız ve yapılandırmanız gerekir. Bu, HACS&apos;ı kullanmak çok kolaydır, ancak manuel olarak da kurabilirsiniz. Daha fazla bilgi için aşağıdaki bağlantıyı ziyaret edin.</value>
+    <value>Bildirimleri kullanmak için Home Assistant'ta HASS.Agent-notifier entegrasyonunu kurmanız ve yapılandırmanız gerekir. Bu, HACS'ı kullanmak çok kolaydır, ancak manuel olarak da kurabilirsiniz. Daha fazla bilgi için aşağıdaki bağlantıyı ziyaret edin.</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo2" xml:space="preserve">
-    <value>Aşağıdaki adımları uyguladığınızdan emin olun: - HASS.Agent-Notifier ve/veya HASS.Agent-MediaPlayer entegrasyonunu kurun - Home Assistant&apos;ı yeniden başlatın -Bir bildirim ve/veya media_player varlığı yapılandırın -Home Assistant&apos;ı yeniden başlatın</value>
+    <value>Aşağıdaki adımları uyguladığınızdan emin olun: - HASS.Agent-Notifier ve/veya HASS.Agent-MediaPlayer entegrasyonunu kurun - Home Assistant'ı yeniden başlatın -Bir bildirim ve/veya media_player varlığı yapılandırın -Home Assistant'ı yeniden başlatın</value>
   </data>
   <data name="OnboardingIntegrations_LblInfo3" xml:space="preserve">
     <value>Aynı şey medya oynatıcı için de geçerlidir; bu entegrasyon, cihazınızı bir media_player varlığı olarak kontrol etmenize, neyin oynatıldığını görmenize ve metinden konuşmaya göndermenize olanak tanır.</value>
@@ -2503,7 +2508,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>HASS.Agent-Entegrasyon GitHub Sayfası</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableLocalApi" xml:space="preserve">
-    <value>Evet, bağlantı noktasında yerel API&apos;yi &amp;etkinleştirin</value>
+    <value>Evet, bağlantı noktasında yerel API'yi &amp;etkinleştirin</value>
   </data>
   <data name="OnboardingLocalApi_CbEnableMediaPlayer" xml:space="preserve">
     <value>&amp;Medya Oynatıcıyı ve metinden konuşmaya (TTS) etkinleştirin</value>
@@ -2512,13 +2517,13 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>&amp;Bildirimleri Etkinleştir</value>
   </data>
   <data name="OnboardingLocalApi_LblInfo1" xml:space="preserve">
-    <value>HASS.Agent&apos;ın kendi dahili API&apos;si vardır, bu nedenle Home Assistant istek gönderebilir (bildirimler veya metinden konuşmaya gibi). Etkinleştirmek istiyor musunuz?</value>
+    <value>HASS.Agent'ın kendi dahili API'si vardır, bu nedenle Home Assistant istek gönderebilir (bildirimler veya metinden konuşmaya gibi). Etkinleştirmek istiyor musunuz?</value>
   </data>
   <data name="OnboardingLocalApi_LblInfo2" xml:space="preserve">
     <value>Hangi modülleri etkinleştirmek istediğinizi seçebilirsiniz. HA entegrasyonları gerektirirler, ancak merak etmeyin, sonraki sayfa bunları nasıl kuracağınız konusunda size daha fazla bilgi verecektir.</value>
   </data>
   <data name="OnboardingLocalApi_LblTip1" xml:space="preserve">
-    <value>Not: 5115 varsayılan bağlantı noktasıdır, yalnızca Home Assistant&apos;ta değiştirdiyseniz değiştirin.</value>
+    <value>Not: 5115 varsayılan bağlantı noktasıdır, yalnızca Home Assistant'ta değiştirdiyseniz değiştirin.</value>
   </data>
   <data name="OnboardingMqtt_CbMqttTls" xml:space="preserve">
     <value>&amp;TLS</value>
@@ -2545,7 +2550,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Pencerenin &amp;başlık çubuğunu göster</value>
   </data>
   <data name="WebViewCommandConfig_CbTopMost" xml:space="preserve">
-    <value>Pencereyi &apos;Her zaman &amp;Üstte&apos; olarak ayarla</value>
+    <value>Pencereyi 'Her zaman &amp;Üstte' olarak ayarla</value>
   </data>
   <data name="WebViewCommandConfig_LblInfo1" xml:space="preserve">
     <value>Web görünümü komutunuzun boyutunu ve konumunu ayarlamak için bu pencereyi sürükleyip yeniden boyutlandırın.</value>
@@ -2557,7 +2562,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Boyut</value>
   </data>
   <data name="WebViewCommandConfig_LblTip1" xml:space="preserve">
-    <value>İpucu: Bir Web Görünümünü kapatmak için ESCAPE&apos;e basın.</value>
+    <value>İpucu: Bir Web Görünümünü kapatmak için ESCAPE'e basın.</value>
   </data>
   <data name="WebViewCommandConfig_LblUrl" xml:space="preserve">
     <value>&amp;URL</value>
@@ -2578,7 +2583,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Durum Bildirimlerini Etkinleştir</value>
   </data>
   <data name="ConfigGeneral_LblInfo5" xml:space="preserve">
-    <value>HASS.Agent, HA&apos;nın kabul edeceğinden emin olmak için cihaz adınızı temizleyecektir, adınızın olduğu gibi kabul edileceğinden eminseniz aşağıdaki bu kuralı geçersiz kılabilirsiniz.</value>
+    <value>HASS.Agent, HA'nın kabul edeceğinden emin olmak için cihaz adınızı temizleyecektir, adınızın olduğu gibi kabul edileceğinden eminseniz aşağıdaki bu kuralı geçersiz kılabilirsiniz.</value>
   </data>
   <data name="ConfigGeneral_LblInfo6" xml:space="preserve">
     <value>HASS.Agent, bir modülün durumu değiştiğinde bildirim gönderir, bu bildirimleri almak isteyip istemediğinizi aşağıdan ayarlayabilirsiniz.</value>
@@ -2644,7 +2649,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Tüm monitörleri uyku (düşük güç) moduna geçirir.</value>
   </data>
   <data name="CommandsManager_MonitorWakeCommandDescription" xml:space="preserve">
-    <value>&apos;Yukarı ok&apos; tuş basımını simüle ederek tüm monitörleri uyandırmaya çalışır.</value>
+    <value>'Yukarı ok' tuş basımını simüle ederek tüm monitörleri uyandırmaya çalışır.</value>
   </data>
   <data name="CommandsManager_SetVolumeCommandDescription" xml:space="preserve">
     <value>Geçerli varsayılan ses cihazının sesini belirtilen düzeye ayarlar.</value>
@@ -2656,7 +2661,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Emretmek</value>
   </data>
   <data name="CommandsMod_MessageBox_Action2" xml:space="preserve">
-    <value>Bir hacim değeri girmezseniz, bu varlığı yalnızca Home Assistant aracılığıyla bir &apos;eylem&apos; değeriyle kullanabilirsiniz. Olduğu gibi çalıştırmak hiçbir şey yapmaz. Bunu istediğinden emin misin?</value>
+    <value>Bir hacim değeri girmezseniz, bu varlığı yalnızca Home Assistant aracılığıyla bir 'eylem' değeriyle kullanabilirsiniz. Olduğu gibi çalıştırmak hiçbir şey yapmaz. Bunu istediğinden emin misin?</value>
   </data>
   <data name="CommandsMod_MessageBox_Sanitize" xml:space="preserve">
     <value>Sağladığınız ad, desteklenmeyen karakterler içeriyor ve çalışmayacak. Önerilen sürüm: {0} Bu sürümü kullanmak istiyor musunuz?</value>
@@ -2674,7 +2679,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>hem yerel API hem de MQTT devre dışı bırakıldı, ancak entegrasyonun çalışması için en az birine ihtiyacı var</value>
   </data>
   <data name="ConfigMqtt_CbEnableMqtt" xml:space="preserve">
-    <value>MQTT&apos;yi etkinleştir</value>
+    <value>MQTT'yi etkinleştir</value>
   </data>
   <data name="ConfigMqtt_LblMqttDisabledWarning" xml:space="preserve">
     <value>MQTT etkinleştirilmezse komutlar ve sensörler çalışmayacaktır!</value>
@@ -2689,7 +2694,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Hizmet şu anda durduruldu ve yapılandırılamıyor. Lütfen yapılandırmak için önce hizmeti başlatın.</value>
   </data>
   <data name="ConfigService_LblInfo5" xml:space="preserve">
-    <value>Servisi yönetmek istiyorsanız (komut ve sensör ekleyin, ayarları değiştirin) buradan veya ana penceredeki &apos;uydu servisi&apos; butonunu kullanarak yapabilirsiniz.</value>
+    <value>Servisi yönetmek istiyorsanız (komut ve sensör ekleyin, ayarları değiştirin) buradan veya ana penceredeki 'uydu servisi' butonunu kullanarak yapabilirsiniz.</value>
   </data>
   <data name="ConfigTrayIcon_CbWebViewShowMenuOnLeftClick" xml:space="preserve">
     <value>Fare sol tıklamasıyla varsayılan menüyü göster</value>
@@ -2698,10 +2703,10 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Home Assistant API jetonunuz doğru görünmüyor. Tüm belirteci seçtiğinizden emin olun (CTRL+A kullanmayın veya çift tıklamayın). Üç bölüm içermelidir (iki nokta ile ayrılmış). Bu şekilde kullanmak istediğinizden emin misiniz?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox2" xml:space="preserve">
-    <value>Ev Asistanı URI&apos;niz doğru görünmüyor. &apos;http://homeassistant.local:8123&apos; veya &apos;https://192.168.0.1:8123&apos; gibi görünmelidir. Bu şekilde kullanmak istediğinizden emin misiniz?</value>
+    <value>Ev Asistanı URI'niz doğru görünmüyor. 'http://homeassistant.local:8123' veya 'https://192.168.0.1:8123' gibi görünmelidir. Bu şekilde kullanmak istediğinizden emin misiniz?</value>
   </data>
   <data name="Configuration_CheckValues_MessageBox3" xml:space="preserve">
-    <value>MQTT broker URI&apos;niz doğru görünmüyor. &apos;homeassistant.local&apos; veya &apos;192.168.0.1&apos; gibi görünmelidir. Bu şekilde kullanmak istediğinizden emin misiniz?</value>
+    <value>MQTT broker URI'niz doğru görünmüyor. 'homeassistant.local' veya '192.168.0.1' gibi görünmelidir. Bu şekilde kullanmak istediğinizden emin misiniz?</value>
   </data>
   <data name="Donate_BtnClose" xml:space="preserve">
     <value>&amp;Kapat</value>
@@ -2734,13 +2739,13 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>İpucu: Hakkında Penceresinde başka bağış yöntemleri de mevcuttur.</value>
   </data>
   <data name="OnboardingIntegrations_CbEnableMediaPlayer" xml:space="preserve">
-    <value>&amp;Media Player&apos;ı etkinleştir (metinden sese dahil)</value>
+    <value>&amp;Media Player'ı etkinleştir (metinden sese dahil)</value>
   </data>
   <data name="OnboardingIntegrations_CbEnableNotifications" xml:space="preserve">
     <value>&amp;Bildirimleri Etkinleştir</value>
   </data>
   <data name="OnboardingMqtt_CbEnableMqtt" xml:space="preserve">
-    <value>MQTT&apos;yi etkinleştir</value>
+    <value>MQTT'yi etkinleştir</value>
   </data>
   <data name="PostUpdate_PostUpdate" xml:space="preserve">
     <value>HASS.Agent Gönderi Güncellemesi</value>
@@ -2752,7 +2757,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Bulunan bluetooth LE cihazlarının miktarını gösteren bir sensör sağlar. Cihazlar ve bağlı durumları nitelik olarak eklenir. Yalnızca son rapordan bu yana görülen cihazları gösterir, ör. sensör yayınlandığında liste temizlenir.</value>
   </data>
   <data name="SensorsManager_GeoLocationSensorDescription" xml:space="preserve">
-    <value>Geçerli enlem, boylam ve yüksekliğinizi virgülle ayrılmış bir değer olarak döndürür. Windows&apos;un konum hizmetlerinin etkinleştirildiğinden emin olun! Windows sürümünüze bağlı olarak bu, yeni kontrol panelinde -&gt; &apos;gizlilik ve güvenlik&apos; -&gt; &apos;konum&apos;da bulunabilir.</value>
+    <value>Geçerli enlem, boylam ve yüksekliğinizi virgülle ayrılmış bir değer olarak döndürür. Windows'un konum hizmetlerinin etkinleştirildiğinden emin olun! Windows sürümünüze bağlı olarak bu, yeni kontrol panelinde -&gt; 'gizlilik ve güvenlik' -&gt; 'konum'da bulunabilir.</value>
   </data>
   <data name="SensorsManager_MicrophoneProcessSensorDescription" xml:space="preserve">
     <value>Şu anda mikrofonu kullanan işlemin adını sağlar. Not: uydu hizmetinde kullanılırsa, kullanıcı alanı uygulamalarını algılamaz.</value>
@@ -2818,7 +2823,7 @@ Lütfen aracınız için credentialları sağlayın, HA Mosquitto eklentisini ku
     <value>Başlangıç modu ayarlanırken hata oluştu, lütfen daha fazla bilgi için günlükleri kontrol edin.</value>
   </data>
   <data name="WebView_InitializeAsync_MessageBox1" xml:space="preserve">
-    <value>Microsoft&apos;un WebView2 çalışma zamanı makinenizde bulunamadı. Bu genellikle yükleyici tarafından gerçekleştirilir, ancak manuel olarak yükleyebilirsiniz. Çalışma zamanı yükleyicisini indirmek istiyor musunuz?</value>
+    <value>Microsoft'un WebView2 çalışma zamanı makinenizde bulunamadı. Bu genellikle yükleyici tarafından gerçekleştirilir, ancak manuel olarak yükleyebilirsiniz. Çalışma zamanı yükleyicisini indirmek istiyor musunuz?</value>
   </data>
   <data name="WebView_InitializeAsync_MessageBox2" xml:space="preserve">
     <value>WebView başlatılırken bir şeyler ters gitti! Lütfen günlüklerinizi kontrol edin ve daha fazla yardım için bir GitHub sorunu açın.</value>


### PR DESCRIPTION
This PR:
- replaces all usages of "keybd_event" as it has been superseded by "SendInput".
- fixes how the input emulation was handled - key was never officially "unpressed" - which caused issues with some of the applications (should remediate https://github.com/LAB02-Research/HASS.Agent/issues/323)
- made the "KeyCommand" modification UI display "keycode name" instead of "keycode number" (for example KEY_P)
- adds note to the "KeyCommand" modification UI about "TAB" key - LCTRL+TAB

I've tested both "KeyCommand" and MediaPlayer - both function as expected after the changes.