### PR TITLE
Fix: PowerShell command action params / PowerShell sensor encoding fix

### DIFF
--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/PowershellCommand.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Commands/PowershellCommand.cs
@@ -45,7 +45,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
             }
 
             var executed = _isScript
-                ? PowershellManager.ExecuteScriptHeadless(Command)
+                ? PowershellManager.ExecuteScriptHeadless(Command, string.Empty)
                 : PowershellManager.ExecuteCommandHeadless(Command);
 
             if (!executed) Log.Error("[POWERSHELL] [{name}] Executing {descriptor} failed", Name, _descriptor, Name);
@@ -57,12 +57,9 @@ namespace HASS.Agent.Shared.HomeAssistant.Commands
         {
             State = "ON";
 
-            // prepare command
-            var command = string.IsNullOrWhiteSpace(Command) ? action : $"{Command} {action}";
-
             var executed = _isScript
-                ? PowershellManager.ExecuteScriptHeadless(command)
-                : PowershellManager.ExecuteCommandHeadless(command);
+                ? PowershellManager.ExecuteScriptHeadless(Command, action)
+                : PowershellManager.ExecuteCommandHeadless(Command);
 
             if (!executed) Log.Error("[POWERSHELL] [{name}] Launching PS {descriptor} with action '{action}' failed", Name, _descriptor, action);
             

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/Managers/PowershellManager.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/Managers/PowershellManager.cs
@@ -208,7 +208,7 @@ namespace HASS.Agent.Shared.Managers
 
 				// attempt to set the right encoding
 				var encoding = CultureInfo.CurrentCulture.TextInfo.OEMCodePage == 1
-					? Encoding.Unicode
+					? Encoding.UTF8
 					: Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
 
 				// prepare the executing process

--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/Managers/PowershellManager.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/Managers/PowershellManager.cs
@@ -8,275 +8,279 @@ using Serilog;
 
 namespace HASS.Agent.Shared.Managers
 {
-    /// <summary>
-    /// Performs powershell-related actions
-    /// </summary>
-    public static class PowershellManager
-    {
-        /// <summary>
-        /// Execute a Powershell command without waiting for or checking results
-        /// </summary>
-        /// <param name="command"></param>
-        /// <returns></returns>
-        public static bool ExecuteCommandHeadless(string command) => ExecuteHeadless(command, string.Empty, false);
+	/// <summary>
+	/// Performs powershell-related actions
+	/// </summary>
+	public static class PowershellManager
+	{
+		/// <summary>
+		/// Execute a Powershell command without waiting for or checking results
+		/// </summary>
+		/// <param name="command"></param>
+		/// <returns></returns>
+		public static bool ExecuteCommandHeadless(string command) => ExecuteHeadless(command, string.Empty, false);
 
-        /// <summary>
-        /// Executes a Powershell script without waiting for or checking results
-        /// </summary>
-        /// <param name="script"></param>
-        /// <param name="parameters"></param>
-        /// <returns></returns>
-        public static bool ExecuteScriptHeadless(string script, string parameters) => ExecuteHeadless(script, parameters, true);
+		/// <summary>
+		/// Executes a Powershell script without waiting for or checking results
+		/// </summary>
+		/// <param name="script"></param>
+		/// <param name="parameters"></param>
+		/// <returns></returns>
+		public static bool ExecuteScriptHeadless(string script, string parameters) => ExecuteHeadless(script, parameters, true);
 
-        private static string GetProcessArguments(string command, string parameters, bool isScript)
-        {
-            if (isScript)
-            {
-                return string.IsNullOrWhiteSpace(parameters) ? $"-File \"{command}\"" : $"-File \"{command}\" \"{parameters}\"";
-            }
-            else
-            {
-                return $@"& {{{command}}}"; //NOTE: place to fix any potential future issues with "command part of the command"
-            }
-        }
+		private static string GetProcessArguments(string command, string parameters, bool isScript)
+		{
+			if (isScript)
+			{
+				return string.IsNullOrWhiteSpace(parameters) ? $"-File \"{command}\"" : $"-File \"{command}\" \"{parameters}\"";
+			}
+			else
+			{
+				return $@"& {{{command}}}"; //NOTE: place to fix any potential future issues with "command part of the command"
+			}
+		}
 
-        private static bool ExecuteHeadless(string command, string parameters, bool isScript)
-        {
-            var descriptor = isScript ? "script" : "command";
+		private static bool ExecuteHeadless(string command, string parameters, bool isScript)
+		{
+			var descriptor = isScript ? "script" : "command";
 
-            try
-            {
-                var workingDir = string.Empty;
-                if (isScript)
-                {
-                    // try to get the script's startup path
-                    var scriptDir = Path.GetDirectoryName(command);
-                    workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
-                }
+			try
+			{
+				var workingDir = string.Empty;
+				if (isScript)
+				{
+					// try to get the script's startup path
+					var scriptDir = Path.GetDirectoryName(command);
+					workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
+				}
 
-                // find the powershell executable
-                var psExec = GetPsExecutable();
-                if (string.IsNullOrEmpty(psExec)) return false;
+				// find the powershell executable
+				var psExec = GetPsExecutable();
+				if (string.IsNullOrEmpty(psExec)) return false;
 
-                // prepare the executing process
-                var processInfo = new ProcessStartInfo
-                {
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    CreateNoWindow = true,
-                    FileName = psExec,
-                    WorkingDirectory = workingDir,
-                    Arguments = GetProcessArguments(command, parameters, isScript)
-                };
+				// prepare the executing process
+				var processInfo = new ProcessStartInfo
+				{
+					WindowStyle = ProcessWindowStyle.Hidden,
+					CreateNoWindow = true,
+					FileName = psExec,
+					WorkingDirectory = workingDir,
+					Arguments = GetProcessArguments(command, parameters, isScript)
+				};
 
-                // launch
-                using var process = new Process();
-                process.StartInfo = processInfo;
-                var start = process.Start();
+				// launch
+				using var process = new Process();
+				process.StartInfo = processInfo;
+				var start = process.Start();
 
-                if (!start)
-                {
-                    Log.Error("[POWERSHELL] Unable to start processing {descriptor}: {command}", descriptor, command);
-                    return false;
-                }
+				if (!start)
+				{
+					Log.Error("[POWERSHELL] Unable to start processing {descriptor}: {command}", descriptor, command);
+					return false;
+				}
 
-                // done
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log.Fatal(ex, "[POWERSHELL] Fatal error when executing {descriptor}: {command}", descriptor, command);
-                return false;
-            }
-        }
+				// done
+				return true;
+			}
+			catch (Exception ex)
+			{
+				Log.Fatal(ex, "[POWERSHELL] Fatal error when executing {descriptor}: {command}", descriptor, command);
+				return false;
+			}
+		}
 
-        /// <summary>
-        /// Execute a Powershell command, logs the output if it fails
-        /// </summary>
-        /// <param name="command"></param>
-        /// <param name="timeout"></param>
-        /// <returns></returns>
-        public static bool ExecuteCommand(string command, TimeSpan timeout) => Execute(command, string.Empty, false, timeout);
+		/// <summary>
+		/// Execute a Powershell command, logs the output if it fails
+		/// </summary>
+		/// <param name="command"></param>
+		/// <param name="timeout"></param>
+		/// <returns></returns>
+		public static bool ExecuteCommand(string command, TimeSpan timeout) => Execute(command, string.Empty, false, timeout);
 
-        /// <summary>
-        /// Executes a Powershell script, logs the output if it fails
-        /// </summary>
-        /// <param name="script"></param>
-        /// <param name="timeout"></param>
-        /// <returns></returns>
-        public static bool ExecuteScript(string script, string parameters, TimeSpan timeout) => Execute(script, parameters, true, timeout);
+		/// <summary>
+		/// Executes a Powershell script, logs the output if it fails
+		/// </summary>
+		/// <param name="script"></param>
+		/// <param name="timeout"></param>
+		/// <returns></returns>
+		public static bool ExecuteScript(string script, string parameters, TimeSpan timeout) => Execute(script, parameters, true, timeout);
 
-        private static bool Execute(string command, string parameters, bool isScript, TimeSpan timeout)
-        {
-            var descriptor = isScript ? "script" : "command";
+		private static bool Execute(string command, string parameters, bool isScript, TimeSpan timeout)
+		{
+			var descriptor = isScript ? "script" : "command";
 
-            try
-            {
-                var workingDir = string.Empty;
-                if (isScript)
-                {
-                    // try to get the script's startup path
-                    var scriptDir = Path.GetDirectoryName(command);
-                    workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
-                }
+			try
+			{
+				var workingDir = string.Empty;
+				if (isScript)
+				{
+					// try to get the script's startup path
+					var scriptDir = Path.GetDirectoryName(command);
+					workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
+				}
 
-                // find the powershell executable
-                var psExec = GetPsExecutable();
-                if (string.IsNullOrEmpty(psExec)) return false;
+				// find the powershell executable
+				var psExec = GetPsExecutable();
+				if (string.IsNullOrEmpty(psExec)) return false;
 
-                // prepare the executing process
-                var processInfo = new ProcessStartInfo
-                {
-                    FileName = psExec,
-                    RedirectStandardError = true,
-                    RedirectStandardOutput = true,
-                    UseShellExecute = false,
-                    WorkingDirectory = workingDir,
-                    Arguments = GetProcessArguments(command, parameters, isScript)
-                };
+				// prepare the executing process
+				var processInfo = new ProcessStartInfo
+				{
+					FileName = psExec,
+					RedirectStandardError = true,
+					RedirectStandardOutput = true,
+					UseShellExecute = false,
+					WorkingDirectory = workingDir,
+					Arguments = GetProcessArguments(command, parameters, isScript)
+				};
 
-                // launch
-                using var process = new Process();
-                process.StartInfo = processInfo;
-                var start = process.Start();
+				// launch
+				using var process = new Process();
+				process.StartInfo = processInfo;
+				var start = process.Start();
 
-                if (!start)
-                {
-                    Log.Error("[POWERSHELL] Unable to start processing {descriptor}: {script}", descriptor, command);
-                    return false;
-                }
+				if (!start)
+				{
+					Log.Error("[POWERSHELL] Unable to start processing {descriptor}: {script}", descriptor, command);
+					return false;
+				}
 
-                // execute and wait
-                process.WaitForExit(Convert.ToInt32(timeout.TotalMilliseconds));
+				// execute and wait
+				process.WaitForExit(Convert.ToInt32(timeout.TotalMilliseconds));
 
-                if (process.ExitCode == 0)
-                {
-                    // done, all good
-                    return true;
-                }
+				if (process.ExitCode == 0)
+				{
+					// done, all good
+					return true;
+				}
 
-                // non-zero exitcode, process as failed
-                Log.Error("[POWERSHELL] The {descriptor} returned non-zero exitcode: {code}", descriptor, process.ExitCode);
+				// non-zero exitcode, process as failed
+				Log.Error("[POWERSHELL] The {descriptor} returned non-zero exitcode: {code}", descriptor, process.ExitCode);
 
-                var errors = process.StandardError.ReadToEnd().Trim();
-                if (!string.IsNullOrEmpty(errors)) Log.Error("[POWERSHELL] Error output:\r\n{output}", errors);
-                else
-                {
-                    var console = process.StandardOutput.ReadToEnd().Trim();
-                    if (!string.IsNullOrEmpty(console)) Log.Error("[POWERSHELL] No error output, console output:\r\n{output}", errors);
-                    else Log.Error("[POWERSHELL] No error and no console output");
-                }
+				var errors = process.StandardError.ReadToEnd().Trim();
+				if (!string.IsNullOrEmpty(errors)) Log.Error("[POWERSHELL] Error output:\r\n{output}", errors);
+				else
+				{
+					var console = process.StandardOutput.ReadToEnd().Trim();
+					if (!string.IsNullOrEmpty(console)) Log.Error("[POWERSHELL] No error output, console output:\r\n{output}", errors);
+					else Log.Error("[POWERSHELL] No error and no console output");
+				}
 
-                // done
-                return false;
-            }
-            catch (Exception ex)
-            {
-                Log.Fatal(ex, "[POWERSHELL] Fatal error when executing {descriptor}: {command}", descriptor, command);
-                return false;
-            }
-        }
+				// done
+				return false;
+			}
+			catch (Exception ex)
+			{
+				Log.Fatal(ex, "[POWERSHELL] Fatal error when executing {descriptor}: {command}", descriptor, command);
+				return false;
+			}
+		}
 
-        /// <summary>
-        /// Executes the command or script, and returns the standard and error output
-        /// </summary>
-        /// <param name="command"></param>
-        /// <param name="timeout"></param>
-        /// <param name="output"></param>
-        /// <param name="errors"></param>
-        /// <returns></returns>
-        internal static bool ExecuteWithOutput(string command, TimeSpan timeout, out string output, out string errors)
-        {
-            output = string.Empty;
-            errors = string.Empty;
+		/// <summary>
+		/// Executes the command or script, and returns the standard and error output
+		/// </summary>
+		/// <param name="command"></param>
+		/// <param name="timeout"></param>
+		/// <param name="output"></param>
+		/// <param name="errors"></param>
+		/// <returns></returns>
+		internal static bool ExecuteWithOutput(string command, TimeSpan timeout, out string output, out string errors)
+		{
+			output = string.Empty;
+			errors = string.Empty;
 
-            try
-            {
-                // check whether we're executing a script
-                var isScript = command.ToLower().EndsWith(".ps1");
+			try
+			{
+				// check whether we're executing a script
+				var isScript = command.ToLower().EndsWith(".ps1");
 
-                var workingDir = string.Empty;
-                if (isScript)
-                {
-                    // try to get the script's startup path
-                    var scriptDir = Path.GetDirectoryName(command);
-                    workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
-                }
+				var workingDir = string.Empty;
+				if (isScript)
+				{
+					// try to get the script's startup path
+					var scriptDir = Path.GetDirectoryName(command);
+					workingDir = !string.IsNullOrEmpty(scriptDir) ? scriptDir : string.Empty;
+				}
 
-                // find the powershell executable
-                var psExec = GetPsExecutable();
-                if (string.IsNullOrEmpty(psExec)) return false;
+				// find the powershell executable
+				var psExec = GetPsExecutable();
+				if (string.IsNullOrEmpty(psExec)) return false;
 
-                // prepare the executing process
-                var processInfo = new ProcessStartInfo
-                {
-                    FileName = psExec,
-                    RedirectStandardError = true,
-                    RedirectStandardOutput = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                    WorkingDirectory = workingDir,
-                    // attempt to set the right encoding
-                    StandardOutputEncoding = Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage),
-                    StandardErrorEncoding = Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage),
-                    // set the right type of arguments
-                    Arguments = isScript
-                        ? $@"& '{command}'"
-                        : $@"& {{{command}}}"
-                };
+				// attempt to set the right encoding
+				var encoding = CultureInfo.CurrentCulture.TextInfo.OEMCodePage == 1
+					? Encoding.Unicode
+					: Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage);
 
-                // execute and wait
-                using var process = new Process();
-                process.StartInfo = processInfo;
+				// prepare the executing process
+				var processInfo = new ProcessStartInfo
+				{
+					FileName = psExec,
+					RedirectStandardError = true,
+					RedirectStandardOutput = true,
+					UseShellExecute = false,
+					CreateNoWindow = true,
+					WorkingDirectory = workingDir,
+					StandardOutputEncoding = encoding,
+					StandardErrorEncoding = encoding,
+					// set the right type of arguments
+					Arguments = isScript
+						? $@"& '{command}'"
+						: $@"& {{{command}}}"
+				};
 
-                var start = process.Start();
-                if (!start)
-                {
-                    Log.Error("[POWERSHELL] Unable to begin executing the {type}: {cmd}", isScript ? "script" : "command", command);
-                    return false;
-                }
+				// execute and wait
+				using var process = new Process();
+				process.StartInfo = processInfo;
 
-                // wait for completion
-                var completed = process.WaitForExit(Convert.ToInt32(timeout.TotalMilliseconds));
-                if (!completed) Log.Error("[POWERSHELL] Timeout executing the {type}: {cmd}", isScript ? "script" : "command", command);
+				var start = process.Start();
+				if (!start)
+				{
+					Log.Error("[POWERSHELL] Unable to begin executing the {type}: {cmd}", isScript ? "script" : "command", command);
+					return false;
+				}
 
-                // read the streams
-                output = process.StandardOutput.ReadToEnd().Trim();
-                errors = process.StandardError.ReadToEnd().Trim();
+				// wait for completion
+				var completed = process.WaitForExit(Convert.ToInt32(timeout.TotalMilliseconds));
+				if (!completed) Log.Error("[POWERSHELL] Timeout executing the {type}: {cmd}", isScript ? "script" : "command", command);
 
-                // dispose of them
-                process.StandardOutput.Dispose();
-                process.StandardError.Dispose();
+				// read the streams
+				output = process.StandardOutput.ReadToEnd().Trim();
+				errors = process.StandardError.ReadToEnd().Trim();
 
-                // make sure the process ends
-                process.Kill();
+				// dispose of them
+				process.StandardOutput.Dispose();
+				process.StandardError.Dispose();
 
-                // done
-                return completed;
-            }
-            catch (Exception ex)
-            {
-                Log.Fatal(ex, ex.Message);
-                return false;
-            }
-        }
+				// make sure the process ends
+				process.Kill();
 
-        /// <summary>
-        /// Attempt to locate powershell.exe
-        /// </summary>
-        /// <returns></returns>
-        public static string GetPsExecutable()
-        {
-            // try regular location
-            var psExec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "WindowsPowerShell\\v1.0\\powershell.exe");
-            if (File.Exists(psExec)) return psExec;
+				// done
+				return completed;
+			}
+			catch (Exception ex)
+			{
+				Log.Fatal(ex, ex.Message);
+				return false;
+			}
+		}
 
-            // try specific
-            psExec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.SystemX86), "WindowsPowerShell\\v1.0\\powershell.exe");
-            if (File.Exists(psExec)) return psExec;
+		/// <summary>
+		/// Attempt to locate powershell.exe
+		/// </summary>
+		/// <returns></returns>
+		public static string GetPsExecutable()
+		{
+			// try regular location
+			var psExec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "WindowsPowerShell\\v1.0\\powershell.exe");
+			if (File.Exists(psExec)) return psExec;
 
-            // not found
-            Log.Error("[POWERSHELL] PS executable not found, make sure you have powershell installed on your system");
-            return string.Empty;
-        }
-    }
+			// try specific
+			psExec = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.SystemX86), "WindowsPowerShell\\v1.0\\powershell.exe");
+			if (File.Exists(psExec)) return psExec;
+
+			// not found
+			Log.Error("[POWERSHELL] PS executable not found, make sure you have powershell installed on your system");
+			return string.Empty;
+		}
+	}
 }


### PR DESCRIPTION
This PR:
- (PowerShell Command) fixes issue raised by @Nesnick https://github.com/LAB02-Research/HASS.Agent/issues/328.
  - changes how arguments are passed on the process launching powershell.exe
- (PowerShell Sensor) fixes issue raised by @Skons & @Zarox666 https://github.com/LAB02-Research/HASS.Agent/issues/343
  - on systems where display culture does not match the keyboard culture (like "en-NL" or "en-PL") the CurrentCulture.TextInfo.OEMCodePage returns 1, this causes encoding parsing to fail
  - changes how encoding for PowerShell process is determined, HASS.Agent tries to derive the encoding from following cultures (in order): InstalledUICulture, CurrentCulture, CurrentUICulture, InvariantCulture
  - it should technically not happen but if the InvariantCulture fails, UTF-8 encoding is returned and warning log printed

-----------------------------------------------------------------------------------------------------------------------------------
PowerShell Command changes have been tested against following script:
```
$wshell = New-Object -ComObject Wscript.Shell
$wshell.Popup("runs " + $PsBoundParameters.Values + $args,1,"Done",0x1)
$PsBoundParameters.Values >> sumlogs.txt
```
and following scenarios:
- normal path to the .ps1 script
- normal path to the .ps1 script and spaces present
- path to the .ps1 script containing non-safe characters and spaces

In all scenarios the payload value has been properly shown by the popup.
**NOTE**: due to how parameters are passed, they need to be retrieved with "$PsBoundParameters" instead of "args[]".

In addition this PR also adds an additional precheck in the "HandleActionReceived" function guarding against null payload (it can happen when payload is specified as an empty string ("") in Home Assistant.