### PR TITLE
Feature: quick action carousel/circular navigation

### DIFF
--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/Main.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/Main.cs
@@ -347,10 +347,15 @@ namespace HASS.Agent.Forms
         /// </summary>
         private async void ShowQuickActions()
         {
+
             // check if quickactions aren't already open, and if there are any actions
             if (HelperFunctions.CheckIfFormIsOpen("QuickActions"))
             {
-                await HelperFunctions.TryBringToFront("QuickActions");
+                var quickActionsForm = HelperFunctions.GetForm("QuickActions") as QuickActions.QuickActions;
+                var result = await HelperFunctions.TryBringToFront(quickActionsForm);
+                if (result)
+                    quickActionsForm.SelectNextQuickActionItem();
+
                 return;
             }
 

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
@@ -108,6 +108,9 @@ namespace HASS.Agent.Forms.QuickActions
                     Row = currentRow
                 };
 
+                // update position when item is selected by mouse cursor
+                panelControl.QuickActionControl.MouseEnter += QuickActionItemMouseEnter;
+
                 // add to list
                 _quickActionPanelControls.Add(panelControl);
 
@@ -127,6 +130,19 @@ namespace HASS.Agent.Forms.QuickActions
                     if (currentRow < rows - 1) currentRow++;
                 }
             }
+        }
+
+        private void QuickActionControl_MouseEnter(object sender, EventArgs e)
+        {
+            throw new NotImplementedException();
+        }
+
+        private void QuickActionItemMouseEnter(object sender, EventArgs e)
+        {
+            var position = PnlActions.GetPositionFromControl(sender as QuickActionControl);
+            _selectedColumn = position.Column;
+            _selectedRow = position.Row;
+            return;
         }
 
         /// <summary>

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
@@ -26,7 +26,10 @@ namespace HASS.Agent.Forms.QuickActions
 
         public QuickActions(List<QuickAction> quickActions)
         {
-            foreach (var quickAction in quickActions) _quickActions.Add(quickAction);
+            foreach (var quickAction in quickActions)
+            {
+                _quickActions.Add(quickAction);
+            }
 
             InitializeComponent();
         }
@@ -55,16 +58,11 @@ namespace HASS.Agent.Forms.QuickActions
 
             // check hass status
             var hass = await CheckHassManagerAsync();
-            if (!hass) CloseWindow();
+            if (!hass)
+                CloseWindow();
 
             // select first item
-            var control = _quickActionPanelControls.Find(x => x.Row == 0 && x.Column == 0);
-            if(control != null)
-            {
-                control.QuickActionControl.OnFocus();
-                _selectedColumn = 0;
-                _selectedRow = 0;
-            }
+            SelectQuickActionItem(0, 0);
         }
 
         /// <summary>
@@ -86,20 +84,29 @@ namespace HASS.Agent.Forms.QuickActions
             // prepare our panel
             PnlActions.AutoSize = true;
 
-            for (var c = 0; c <= _columns; c++) PnlActions.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 152));
             PnlActions.ColumnCount = _columns;
-
-            for (var r = 0; r <= _columns; r++) PnlActions.RowStyles.Add(new RowStyle(SizeType.Absolute, 255));
             PnlActions.RowCount = _rows;
 
             PnlActions.CellBorderStyle = TableLayoutPanelCellBorderStyle.None;
+
+            for (var c = 0; c <= _columns; c++)
+            {
+                PnlActions.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 152));
+            }
+
+            for (var r = 0; r <= _columns; r++)
+            {
+                PnlActions.RowStyles.Add(new RowStyle(SizeType.Absolute, 255));
+            }
 
             // resize window
             Width = 152 * columns + 20;
             Height = 255 * rows + 30;
 
-            if (columns > 1) Width += 5 * (columns - 1);
-            if (rows > 1) Height += 5 * (rows - 1);
+            if (columns > 1)
+                Width += 5 * (columns - 1);
+            if (rows > 1)
+                Height += 5 * (rows - 1);
 
             // add the quickactions as controls
             var currentColumn = 0;
@@ -121,19 +128,29 @@ namespace HASS.Agent.Forms.QuickActions
                 _quickActionPanelControls.Add(panelControl);
 
                 // store position
-                if (!_rowColumnCounts.ContainsKey(currentRow)) _rowColumnCounts.Add(currentRow, currentColumn);
-                else _rowColumnCounts[currentRow] = currentColumn;
+                if (!_rowColumnCounts.ContainsKey(currentRow))
+                {
+                    _rowColumnCounts.Add(currentRow, currentColumn);
+                }
+                else
+                {
+                    _rowColumnCounts[currentRow] = currentColumn;
+                }
 
                 // add to the panel
                 PnlActions.Controls.Add(quickAction, currentColumn, currentRow);
 
                 // set next column & row
-                if (currentColumn < columns - 1) currentColumn++;
+                if (currentColumn < columns - 1)
+                {
+                    currentColumn++;
+                }
                 else
                 {
                     // on to the next row (if there is one)
                     currentColumn = 0;
-                    if (currentRow < rows - 1) currentRow++;
+                    if (currentRow < rows - 1)
+                        currentRow++;
                 }
             }
         }
@@ -151,8 +168,10 @@ namespace HASS.Agent.Forms.QuickActions
         /// </summary>
         internal void CloseWindow()
         {
-            if (!IsHandleCreated) return;
-            if (IsDisposed) return;
+            if (!IsHandleCreated)
+                return;
+            if (IsDisposed)
+                return;
 
             Invoke(new MethodInvoker(delegate
             {
@@ -204,8 +223,10 @@ namespace HASS.Agent.Forms.QuickActions
         /// <param name="loading"></param>
         private void SetGuiLoading(bool loading)
         {
-            if (!IsHandleCreated) return;
-            if (IsDisposed) return;
+            if (!IsHandleCreated)
+                return;
+            if (IsDisposed)
+                return;
 
             Invoke(new MethodInvoker(delegate
             {
@@ -237,6 +258,25 @@ namespace HASS.Agent.Forms.QuickActions
         }
 
         /// <summary>
+        /// Selects QuickAction item at given position
+        /// </summary>
+        /// <param name="msg"></param>
+        /// <param name="keyData"></param>
+        /// <returns></returns>
+        private bool SelectQuickActionItem(int row, int column)
+        {
+            var control = _quickActionPanelControls.Find(x => x.Row == row && x.Column == column);
+            if (control == null)
+                return false;
+
+            control.QuickActionControl.OnFocus();
+            _selectedColumn = column;
+            _selectedRow = row;
+
+            return true;
+        }
+
+        /// <summary>
         /// Intercepts and processes the arrow keys
         /// </summary>
         /// <param name="msg"></param>
@@ -246,113 +286,81 @@ namespace HASS.Agent.Forms.QuickActions
         {
             try
             {
-                // if never pressed before ..
+                // should not happen, but select first item if nothing is selected
                 if (_selectedColumn == -1)
                 {
-                    // .. always select first one
-                    var control = _quickActionPanelControls.Find(x => x.Row == 0 && x.Column == 0);
-                    if (control == null) return true;
+                    SelectQuickActionItem(0, 0);
 
-                    control.QuickActionControl.OnFocus();
-                    _selectedColumn = 0;
-                    _selectedRow = 0;
                     return true;
                 }
 
                 if (keyData == Keys.Down)
                 {
-                    // is there a next row?
+                    // wrap up if we're at the last row
                     if (_selectedRow == _rows - 1)
                     {
-                        var nextControl = _quickActionPanelControls.Find(x => x.Row == 0 && x.Column == _selectedColumn);
+                        SelectQuickActionItem(0, _selectedColumn);
 
-                        nextControl.QuickActionControl.OnFocus();
-                        _selectedRow = 0;
                         return true;
                     }
 
-                    // jep, select the control below (or the last)
-                    _selectedRow++;
-                    var control = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == _selectedColumn);
-                    if (control == null)
+                    var selected = SelectQuickActionItem(_selectedRow + 1, _selectedColumn);
+                    if (!selected)
                     {
-                        // none found with same column, get the last
-                        _selectedColumn = _rowColumnCounts[_selectedRow];
-                        control = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == _selectedColumn);
-                        control?.QuickActionControl.OnFocus();
-                        return true;
+                        SelectQuickActionItem(_selectedRow + 1, _rowColumnCounts[_selectedRow + 1]);
                     }
 
-                    control.QuickActionControl.OnFocus();
                     return true;
                 }
 
                 if (keyData == Keys.Right)
                 {
-                    // is there a next column?
+                    // wrap up to left is we're at the last column
                     var maxColumnsForRow = _rowColumnCounts[_selectedRow];
                     if (_selectedColumn == maxColumnsForRow)
                     {
-                        var nextControl = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == 0);
+                        SelectQuickActionItem(_selectedRow, 0);
 
-                        nextControl.QuickActionControl.OnFocus();
-                        _selectedColumn = 0;
                         return true;
                     }
 
-                    // jep, select the control to the right
-                    _selectedColumn++;
-                    var control = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == _selectedColumn);
-                    control?.QuickActionControl.OnFocus();
+                    SelectQuickActionItem(_selectedRow, _selectedColumn + 1);
+
                     return true;
                 }
 
                 if (keyData == Keys.Left)
                 {
-                    // is there a previous column?
+                    // wrap up to right is we're at the first column
                     if (_selectedColumn == 0)
                     {
                         var maxColumnsForRow = _rowColumnCounts[_selectedRow];
-                        var nextControl = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == maxColumnsForRow);
+                        SelectQuickActionItem(_selectedRow, maxColumnsForRow);
 
-                        nextControl.QuickActionControl.OnFocus();
-                        _selectedColumn = maxColumnsForRow;
                         return true;
                     }
 
-                    // jep, select the control to the left
-                    _selectedColumn--;
-                    var control = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == _selectedColumn);
-                    control?.QuickActionControl.OnFocus();
+                    SelectQuickActionItem(_selectedRow, _selectedColumn - 1);
+
                     return true;
                 }
 
                 if (keyData == Keys.Up)
                 {
-                    // is there a previous row?
+                    // wrap down if we're at the last row
                     if (_selectedRow == 0)
                     {
-                        var nextRow = _rows - 1;
-                        var nextControl = _quickActionPanelControls.Find(x => x.Row == nextRow && x.Column == _selectedColumn);
+                        SelectQuickActionItem(_rows - 1, _rowColumnCounts[_rows - 1]);
 
-                        nextControl.QuickActionControl.OnFocus();
-                        _selectedRow = nextRow;
                         return true;
                     }
 
-                    // jep, select the control above (or the last)
-                    _selectedRow--;
-                    var control = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == _selectedColumn);
-                    if (control == null)
+                    var selected = SelectQuickActionItem(_selectedRow - 1, _selectedColumn);
+                    if (!selected)
                     {
-                        // none found with same column, get the first
-                        _selectedColumn = 0;
-                        control = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == _selectedColumn);
-                        control?.QuickActionControl.OnFocus();
-                        return true;
+                        SelectQuickActionItem(_selectedRow - 1, _rowColumnCounts[_selectedRow - 1]);
                     }
 
-                    control.QuickActionControl.OnFocus();
                     return true;
                 }
             }
@@ -376,19 +384,15 @@ namespace HASS.Agent.Forms.QuickActions
             if (_selectedColumn == maxColumnsForRow)
             {
                 // wrap up to first row if there is nothing below
-                if (_selectedRow == (_rows - 1)) { _selectedRow = 0; } else { _selectedRow++; }
+                var nextRow = _selectedRow == (_rows - 1) ? 0 : _selectedRow + 1;
+                SelectQuickActionItem(nextRow, 0);
 
-                var nextControl = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == 0);
-
-                nextControl.QuickActionControl.OnFocus();
-                _selectedColumn = 0;
                 return;
             }
 
             // select the control to the right
-            _selectedColumn++;
-            var control = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == _selectedColumn);
-            control?.QuickActionControl.OnFocus();
+            SelectQuickActionItem(_selectedRow, _selectedColumn + 1);
+
             return;
         }
 
@@ -400,9 +404,12 @@ namespace HASS.Agent.Forms.QuickActions
 
         private void QuickActions_ResizeEnd(object sender, EventArgs e)
         {
-            if (Variables.ShuttingDown) return;
-            if (!IsHandleCreated) return;
-            if (IsDisposed) return;
+            if (Variables.ShuttingDown)
+                return;
+            if (!IsHandleCreated)
+                return;
+            if (IsDisposed)
+                return;
 
             try
             {

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
@@ -12,7 +12,7 @@ namespace HASS.Agent.Forms.QuickActions
     public partial class QuickActions : MetroForm
     {
         public event EventHandler ClearFocus;
-        
+
         private readonly List<QuickAction> _quickActions = new();
         private readonly List<QuickActionPanelControl> _quickActionPanelControls = new();
 
@@ -73,7 +73,7 @@ namespace HASS.Agent.Forms.QuickActions
 
             _columns = columns;
             _rows = rows;
-            
+
             // prepare our panel
             PnlActions.AutoSize = true;
 
@@ -84,7 +84,7 @@ namespace HASS.Agent.Forms.QuickActions
             PnlActions.RowCount = _rows;
 
             PnlActions.CellBorderStyle = TableLayoutPanelCellBorderStyle.None;
-            
+
             // resize window
             Width = 152 * columns + 20;
             Height = 255 * rows + 30;
@@ -111,7 +111,7 @@ namespace HASS.Agent.Forms.QuickActions
                 // store position
                 if (!_rowColumnCounts.ContainsKey(currentRow)) _rowColumnCounts.Add(currentRow, currentColumn);
                 else _rowColumnCounts[currentRow] = currentColumn;
-                
+
                 // add to the panel
                 PnlActions.Controls.Add(quickAction, currentColumn, currentRow);
 
@@ -242,7 +242,14 @@ namespace HASS.Agent.Forms.QuickActions
                 if (keyData == Keys.Down)
                 {
                     // is there a next row?
-                    if (_selectedRow == _rows - 1) return true;
+                    if (_selectedRow == _rows - 1)
+                    {
+                        var nextControl = _quickActionPanelControls.Find(x => x.Row == 0 && x.Column == _selectedColumn);
+
+                        nextControl.QuickActionControl.OnFocus();
+                        _selectedRow = 0;
+                        return true;
+                    }
 
                     // jep, select the control below (or the last)
                     _selectedRow++;
@@ -264,7 +271,14 @@ namespace HASS.Agent.Forms.QuickActions
                 {
                     // is there a next column?
                     var maxColumnsForRow = _rowColumnCounts[_selectedRow];
-                    if (_selectedColumn == maxColumnsForRow) return true;
+                    if (_selectedColumn == maxColumnsForRow)
+                    {
+                        var nextControl = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == 0);
+
+                        nextControl.QuickActionControl.OnFocus();
+                        _selectedColumn = 0;
+                        return true;
+                    }
 
                     // jep, select the control to the right
                     _selectedColumn++;
@@ -276,7 +290,15 @@ namespace HASS.Agent.Forms.QuickActions
                 if (keyData == Keys.Left)
                 {
                     // is there a previous column?
-                    if (_selectedColumn == 0) return true;
+                    if (_selectedColumn == 0)
+                    {
+                        var maxColumnsForRow = _rowColumnCounts[_selectedRow];
+                        var nextControl = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == maxColumnsForRow);
+
+                        nextControl.QuickActionControl.OnFocus();
+                        _selectedColumn = maxColumnsForRow;
+                        return true;
+                    }
 
                     // jep, select the control to the left
                     _selectedColumn--;
@@ -288,7 +310,15 @@ namespace HASS.Agent.Forms.QuickActions
                 if (keyData == Keys.Up)
                 {
                     // is there a previous row?
-                    if (_selectedRow == 0) return true;
+                    if (_selectedRow == 0)
+                    {
+                        var nextRow = _rows - 1;
+                        var nextControl = _quickActionPanelControls.Find(x => x.Row == nextRow && x.Column == _selectedColumn);
+
+                        nextControl.QuickActionControl.OnFocus();
+                        _selectedRow = nextRow;
+                        return true;
+                    }
 
                     // jep, select the control above (or the last)
                     _selectedRow--;

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
@@ -138,11 +138,6 @@ namespace HASS.Agent.Forms.QuickActions
             }
         }
 
-        private void QuickActionControl_MouseEnter(object sender, EventArgs e)
-        {
-            throw new NotImplementedException();
-        }
-
         private void QuickActionItemMouseEnter(object sender, EventArgs e)
         {
             var position = PnlActions.GetPositionFromControl(sender as QuickActionControl);

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
@@ -304,10 +304,11 @@ namespace HASS.Agent.Forms.QuickActions
                         return true;
                     }
 
-                    var selected = SelectQuickActionItem(_selectedRow + 1, _selectedColumn);
+                    var nextRow = _selectedRow + 1;
+                    var selected = SelectQuickActionItem(nextRow, _selectedColumn);
                     if (!selected)
                     {
-                        SelectQuickActionItem(_selectedRow + 1, _rowColumnCounts[_selectedRow + 1]);
+                        SelectQuickActionItem(nextRow, _rowColumnCounts[nextRow]);
                     }
 
                     return true;
@@ -345,29 +346,27 @@ namespace HASS.Agent.Forms.QuickActions
                     SelectQuickActionItem(_selectedRow, _selectedColumn - 1);
 
                     return true;
-                    /*                    // wrap up to bottom is we're at the first column
-
-                                        var nextRow = _selectedColumn == 0 ? _selectedRow - 1 : _selectedRow;
-                                        var nextColumn = _selectedColumn == 0 ? _rowColumnCounts[nextRow] : _selectedColumn - 1;
-                                        SelectQuickActionItem(nextRow, nextColumn);
-
-                                        return true;*/
                 }
 
                 if (keyData == Keys.Up)
                 {
-                    // wrap down if we're at the last row
+                    var nextRow = _selectedRow - 1;
+
+                    // wrap down if we're at the first row
                     if (_selectedRow == 0)
                     {
-                        SelectQuickActionItem(_rows - 1, _rowColumnCounts[_rows - 1]);
+                        nextRow = _rows - 1;
+                        var maxColumnsForNextRow = _rowColumnCounts[nextRow];
+                        var nextColumn = maxColumnsForNextRow < _selectedColumn ? maxColumnsForNextRow : _selectedColumn;
+                        SelectQuickActionItem(nextRow, nextColumn);
 
                         return true;
                     }
 
-                    var selected = SelectQuickActionItem(_selectedRow - 1, _selectedColumn);
+                    var selected = SelectQuickActionItem(nextRow, _selectedColumn);
                     if (!selected)
                     {
-                        SelectQuickActionItem(_selectedRow - 1, _rowColumnCounts[_selectedRow - 1]);
+                        SelectQuickActionItem(nextRow, _rowColumnCounts[nextRow]);
                     }
 
                     return true;

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
@@ -315,11 +315,13 @@ namespace HASS.Agent.Forms.QuickActions
 
                 if (keyData == Keys.Right)
                 {
-                    // wrap up to left is we're at the last column
                     var maxColumnsForRow = _rowColumnCounts[_selectedRow];
+
+                    // wrap up to first row if there is nothing below
                     if (_selectedColumn == maxColumnsForRow)
                     {
-                        SelectQuickActionItem(_selectedRow, 0);
+                        var nextRow = _selectedRow == (_rows - 1) ? 0 : _selectedRow + 1;
+                        SelectQuickActionItem(nextRow, 0);
 
                         return true;
                     }
@@ -331,11 +333,11 @@ namespace HASS.Agent.Forms.QuickActions
 
                 if (keyData == Keys.Left)
                 {
-                    // wrap up to right is we're at the first column
+                    // wrap up to last row if there is nothing above
                     if (_selectedColumn == 0)
                     {
-                        var maxColumnsForRow = _rowColumnCounts[_selectedRow];
-                        SelectQuickActionItem(_selectedRow, maxColumnsForRow);
+                        var nextRow = _selectedRow == 0 ? _rows - 1 : _selectedRow - 1;
+                        SelectQuickActionItem(nextRow, _rowColumnCounts[nextRow]);
 
                         return true;
                     }
@@ -343,6 +345,13 @@ namespace HASS.Agent.Forms.QuickActions
                     SelectQuickActionItem(_selectedRow, _selectedColumn - 1);
 
                     return true;
+                    /*                    // wrap up to bottom is we're at the first column
+
+                                        var nextRow = _selectedColumn == 0 ? _selectedRow - 1 : _selectedRow;
+                                        var nextColumn = _selectedColumn == 0 ? _rowColumnCounts[nextRow] : _selectedColumn - 1;
+                                        SelectQuickActionItem(nextRow, nextColumn);
+
+                                        return true;*/
                 }
 
                 if (keyData == Keys.Up)
@@ -380,17 +389,15 @@ namespace HASS.Agent.Forms.QuickActions
         {
             var maxColumnsForRow = _rowColumnCounts[_selectedRow];
 
-            // are we at the end of the row?
+            // are we at the end of the row / wrap up to first row if there is nothing below
             if (_selectedColumn == maxColumnsForRow)
             {
-                // wrap up to first row if there is nothing below
                 var nextRow = _selectedRow == (_rows - 1) ? 0 : _selectedRow + 1;
                 SelectQuickActionItem(nextRow, 0);
 
                 return;
             }
 
-            // select the control to the right
             SelectQuickActionItem(_selectedRow, _selectedColumn + 1);
 
             return;

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
@@ -58,7 +58,13 @@ namespace HASS.Agent.Forms.QuickActions
             if (!hass) CloseWindow();
 
             // select first item
-            _quickActionPanelControls.Find(x => x.Row == 0 && x.Column == 0)?.QuickActionControl.OnFocus();
+            var control = _quickActionPanelControls.Find(x => x.Row == 0 && x.Column == 0);
+            if(control != null)
+            {
+                control.QuickActionControl.OnFocus();
+                _selectedColumn = 0;
+                _selectedRow = 0;
+            }
         }
 
         /// <summary>

--- a/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Forms/QuickActions/QuickActions.cs
@@ -56,6 +56,9 @@ namespace HASS.Agent.Forms.QuickActions
             // check hass status
             var hass = await CheckHassManagerAsync();
             if (!hass) CloseWindow();
+
+            // select first item
+            _quickActionPanelControls.Find(x => x.Row == 0 && x.Column == 0)?.QuickActionControl.OnFocus();
         }
 
         /// <summary>
@@ -343,6 +346,33 @@ namespace HASS.Agent.Forms.QuickActions
 
             // ignore the rest
             return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        /// <summary>
+        /// Selects next Quick Action item following right->down->up pattern
+        /// </summary>
+        public void SelectNextQuickActionItem()
+        {
+            var maxColumnsForRow = _rowColumnCounts[_selectedRow];
+
+            // are we at the end of the row?
+            if (_selectedColumn == maxColumnsForRow)
+            {
+                // wrap up to first row if there is nothing below
+                if (_selectedRow == (_rows - 1)) { _selectedRow = 0; } else { _selectedRow++; }
+
+                var nextControl = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == 0);
+
+                nextControl.QuickActionControl.OnFocus();
+                _selectedColumn = 0;
+                return;
+            }
+
+            // select the control to the right
+            _selectedColumn++;
+            var control = _quickActionPanelControls.Find(x => x.Row == _selectedRow && x.Column == _selectedColumn);
+            control?.QuickActionControl.OnFocus();
+            return;
         }
 
         /// <summary>

--- a/src/HASS.Agent.Staging/HASS.Agent/Functions/HelperFunctions.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Functions/HelperFunctions.cs
@@ -488,7 +488,7 @@ namespace HASS.Agent.Functions
             // show a new webview from within the UI thread
             LaunchTrayIconCustomWebView(webViewInfo);
         }
-        
+
         private static void LaunchTrayIconBackgroundLoadedWebView()
         {
             Variables.MainForm.Invoke(new MethodInvoker(delegate
@@ -568,14 +568,12 @@ namespace HASS.Agent.Functions
         /// <summary>
         /// Attempts to bring the provided form to the foreground if it's open
         /// </summary>
-        /// <param name="formName"></param>
+        /// <param name="form"></param>
         /// <returns></returns>
-        internal static async Task<bool> TryBringToFront(string formName)
+        internal static async Task<bool> TryBringToFront(Form form)
         {
             try
             {
-                // is it open?
-                var form = Application.OpenForms.Cast<Form>().FirstOrDefault(x => x.Name == formName);
                 if (form == null) return false;
 
                 // yep, check if we need to undo minimized
@@ -588,6 +586,25 @@ namespace HASS.Agent.Functions
 
                 // done
                 return true;
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, ex.Message);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to bring the provided form to the foreground if it's open
+        /// </summary>
+        /// <param name="formName"></param>
+        /// <returns></returns>
+        internal static async Task<bool> TryBringToFront(string formName)
+        {
+            try
+            {
+                var form = GetForm(formName);
+                return await TryBringToFront(form);
             }
             catch (Exception ex)
             {
@@ -644,16 +661,16 @@ namespace HASS.Agent.Functions
                 return false;
             }
         }
-        
+
         /// <summary>
         /// Returns the configured device name, or a safe version of the machinename if nothing's stored
         /// </summary>
         /// <returns></returns>
         internal static string GetConfiguredDeviceName() =>
-            string.IsNullOrEmpty(Variables.AppSettings?.DeviceName) 
-                ? SharedHelperFunctions.GetSafeDeviceName() 
+            string.IsNullOrEmpty(Variables.AppSettings?.DeviceName)
+                ? SharedHelperFunctions.GetSafeDeviceName()
                 : SharedHelperFunctions.GetSafeValue(Variables.AppSettings.DeviceName);
-        
+
         /// <summary>
         /// Checks whether the process is currently running under the current user, by default ignoring the current process
         /// </summary>

--- a/src/HASS.Agent.Staging/HASS.Agent/Functions/HelperFunctions.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Functions/HelperFunctions.cs
@@ -364,6 +364,8 @@ namespace HASS.Agent.Functions
         /// <returns></returns>
         internal static bool CheckIfFormIsOpen(string formname) => Application.OpenForms.Cast<Form>().Any(form => form?.Name == formname);
 
+        internal static Form GetForm(string formName) => Application.OpenForms.Cast<Form>().FirstOrDefault(x => x.Name == formName);
+
         /// <summary>
         /// Launches the url with the user's custom browser if provided, or the system's default
         /// </summary>

--- a/src/HASS.Agent.Staging/HASS.Agent/Functions/HelperFunctions.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent/Functions/HelperFunctions.cs
@@ -360,9 +360,9 @@ namespace HASS.Agent.Functions
         /// <summary>
         /// Checks whether the provided form is already opened
         /// </summary>
-        /// <param name="formname"></param>
+        /// <param name="formName"></param>
         /// <returns></returns>
-        internal static bool CheckIfFormIsOpen(string formname) => Application.OpenForms.Cast<Form>().Any(form => form?.Name == formname);
+        internal static bool CheckIfFormIsOpen(string formName) => Application.OpenForms.Cast<Form>().Any(form => form?.Name == formName);
 
         internal static Form GetForm(string formName) => Application.OpenForms.Cast<Form>().FirstOrDefault(x => x.Name == formName);
 


### PR DESCRIPTION
This PR adds features to the Quick Actions window requested by @ASchneiderBR in https://github.com/LAB02-Research/HASS.Agent/issues/327

Detailed changes (Edited as per below discussion):
- first item should be always selected when Quick Actions window is displayed
- pressing left arrow key selects the next item to the left unless there is none, then first item in the next row below is selected
- pressing right arrow key selects previous item to the right unless there is none, then last item in the above row is selected
- pressing left/right arrow key when "first" or "last" in general is selected causes the selection to wrap up to the end/begining
- pressing up/down arrow key moves selection respective to the column
- pressing the Quick Action shortcut repeatedly while Quick Action window is opened will cause the next Quick Action item to be selected (in order of right -> down -> up)

Video presenting the new behaviour: (white text box shows which keyboard keys are being pressed)



https://github.com/LAB02-Research/HASS.Agent.Staging/assets/68441479/102f1d24-fc9f-461f-89b7-923f86edf76a

