### PR TITLE
Fix: performance counter calling NextValue() twice

### DIFF
--- a/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/PerformanceCounterSensor.cs
+++ b/src/HASS.Agent.Staging/HASS.Agent.Shared/HomeAssistant/Sensors/PerformanceCounterSensor.cs
@@ -69,7 +69,7 @@ namespace HASS.Agent.Shared.HomeAssistant.Sensors
             }
 
             // done
-            return Math.Round(Counter.NextValue()).ToString(CultureInfo.CurrentCulture);
+            return Math.Round(nextVal).ToString(CultureInfo.CurrentCulture);
         }
 
         public override string GetAttributes() => string.Empty;


### PR DESCRIPTION
This PR fixes issue reported via https://github.com/LAB02-Research/HASS.Agent/issues/331

The PerformanceCounter sensor calls NextValue() twice causing the returned percentage to be malformed (NextValue() cannot be called too often).